### PR TITLE
Auto-load default modules on app startup

### DIFF
--- a/PRODUCT_BACKLOG.md
+++ b/PRODUCT_BACKLOG.md
@@ -55,6 +55,9 @@ Deliverables / Acceptance Criteria:
 
 Recent Progress (UI & Interaction):
 
+- [x] Auto-load default modules on app startup (happens automatically when audio context initializes)
+- [x] Dynamic Load/Clear button: shows "Load Default Modules" when grid is empty, "Clear" when modules present
+- [x] Clear functionality: removes all modules and connections from workspace
 - [x] Patch workspace with pan/zoom, grid with snap, and background panning
 - [x] Precise port center alignment (runtime measurement with world-space offsets)
 - [x] Click-to-click cable connection with live pending path
@@ -170,6 +173,18 @@ Validated Test Cases:
 - ✅ Both use ConstantSource → GainNode for gate signals
 - ✅ Both work interchangeably with VCO pitch CV and gate inputs
 - ✅ VCO correctly handles pitch CV from either source (base frequency = 0 when connected)
+
+11. **Auto-Load Default Modules & Clear Functionality**:
+
+- ✅ Default modules auto-load when app starts and audio context initializes
+- ✅ Button shows "Load Default Modules" when workspace is empty (0 modules)
+- ✅ Button shows "Clear" when workspace has any modules (≥1 modules)
+- ✅ "Load Default Modules" creates default patch: SEQUENCER → VCO → VCF → MASTER OUT
+- ✅ "Clear" removes all modules and connections from workspace
+- ✅ Clear disposes all audio nodes properly (no memory leaks)
+- ✅ Clear resets positioned modules array (empty grid after clear)
+- ✅ Auto-load only happens once per audio context initialization
+- ✅ Re-initialization of audio context triggers auto-load again
 
 ### 1. Filter Section - HIGH PRIORITY
 

--- a/src/components/patch/PatchWorkspace.tsx
+++ b/src/components/patch/PatchWorkspace.tsx
@@ -165,6 +165,13 @@ export const PatchWorkspace: React.FC = () => {
     }
   }, [audioContext, patch]);
 
+  const handleClearAll = React.useCallback(() => {
+    // Clear all modules and connections from the patch
+    patch.clearPatch();
+    // Clear all positioned modules from the UI
+    setPositionedModules([]);
+  }, [patch]);
+
   const [startError, setStartError] = React.useState<Error | null>(null);
 
   const handleStart = async () => {
@@ -176,10 +183,12 @@ export const PatchWorkspace: React.FC = () => {
     }
   };
 
-  // Once the AudioContext becomes available the first time, create initial modules
+  // Once the AudioContext becomes available the first time, auto-load default modules
   React.useEffect(() => {
     if (audioContext && !hasAudioContextInitializedRef.current) {
       hasAudioContextInitializedRef.current = true;
+      // Auto-load default modules on first audio context initialization
+      handleAddInitialModules();
     }
     if (!audioContext && hasAudioContextInitializedRef.current) {
       // Reset so that if a brand new context is created later we can auto-load again
@@ -548,10 +557,16 @@ export const PatchWorkspace: React.FC = () => {
         >
           <div className="module-palette" aria-label="Module palette">
             <button
-              onClick={handleAddInitialModules}
+              onClick={
+                Object.keys(patch.modules).length === 0
+                  ? handleAddInitialModules
+                  : handleClearAll
+              }
               className="secondary-button"
             >
-              Load Default Modules
+              {Object.keys(patch.modules).length === 0
+                ? "Load Default Modules"
+                : "Clear"}
             </button>
             <button onClick={() => addModuleByType("VCO")}>ADD VCO</button>
             <button onClick={() => addModuleByType("VCF")}>ADD VCF</button>
@@ -595,17 +610,6 @@ export const PatchWorkspace: React.FC = () => {
               </button>
             )}
           </div>
-          {Object.keys(patch.modules).length === 0 && (
-            <div
-              style={{
-                padding: "0.5rem",
-                fontSize: "0.85rem",
-                color: "#888",
-              }}
-            >
-              Initial modules not yet loaded.
-            </div>
-          )}
           <div
             className="modules-layer"
             style={{


### PR DESCRIPTION
### Changes:
- Auto-load default modules when audio context initializes
- Button shows "Load Default Modules" when workspace is empty
- Button shows "Clear" when modules are present on the grid
- Clear button removes all modules, connections, and resets workspace
- Removed "Initial modules not yet loaded" message

### Implementation:
- Updated useEffect to call handleAddInitialModules on first audio context init
- Added handleClearAll callback to clear patch and positioned modules
- Made button dynamic based on patch.modules count
- Updated PRODUCT_BACKLOG.md with new acceptance criteria

### Acceptance Criteria:
✅ Default modules auto-load on app startup
✅ Button text changes based on workspace state
✅ Clear functionality disposes all audio nodes properly ✅ Auto-load only happens once per audio context initialization ✅ All quality checks pass (lintfix, stylelintfix, typecheck, test)