### PR TITLE
Add LFO module for parameter modulation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1030,3 +1030,27 @@
   border: 1px solid #333;
   border-radius: 4px;
 }
+
+/* LFO Reset button */
+.reset-button {
+  width: 100%;
+  padding: 5px 10px;
+  background: #2a2a2a;
+  color: #ccc;
+  border: 1px solid #555;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.reset-button:hover {
+  background: #3a3a3a;
+  border-color: #777;
+  color: #fff;
+}
+
+.reset-button:active {
+  background: #1a1a1a;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1010,3 +1010,23 @@
   text-align: center;
   margin-top: 2px;
 }
+
+/* LFO Waveform Preview */
+.lfo-preview-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 6px;
+}
+
+.lfo-waveform-preview {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.lfo-waveform-preview canvas {
+  display: block;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 4px;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -959,3 +959,54 @@
   margin: auto;
   opacity: 0.7;
 }
+
+/* Toggle Button Group (e.g., for LFO bipolar/unipolar) */
+.toggle-button-group {
+  display: flex;
+  gap: 2px;
+  background: #1a1a1a;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 2px;
+  grid-column: 1 / span 2;
+}
+
+.toggle-button {
+  flex: 1;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: #888;
+  font-size: 10px;
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    color 0.15s;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.toggle-button:hover {
+  background: #2a2a2a;
+  color: #bbb;
+}
+
+.toggle-button.active {
+  background: #3a5a3a;
+  color: #8f8;
+  box-shadow: 0 0 4px rgb(136 255 136 / 20%);
+}
+
+.toggle-button.active:hover {
+  background: #4a6a4a;
+}
+
+/* Module control hint text */
+.module-control-hint {
+  grid-column: 1 / span 2;
+  font-size: 9px;
+  color: #666;
+  text-align: center;
+  margin-top: 2px;
+}

--- a/src/components/patch/ModuleContainer.tsx
+++ b/src/components/patch/ModuleContainer.tsx
@@ -2,6 +2,7 @@ import React from "react";
 
 import { type ModuleInstance, type PortDefinition } from "../../modular/types";
 import { AHDSRControls } from "./controls/AHDSRControls";
+import { LFOControls } from "./controls/LFOControls";
 import { MasterOutputControls } from "./controls/MasterOutputControls";
 import { MIDIInputControls } from "./controls/MIDIInputControls";
 import { SaturatorControls } from "./controls/SaturatorControls";
@@ -15,6 +16,7 @@ enum ModuleType {
   VCF = "VCF",
   ADSR = "ADSR",
   SATURATOR = "SATURATOR",
+  LFO = "LFO",
   MIDI_INPUT = "MIDI_INPUT",
   SEQUENCER = "SEQUENCER",
   MASTER_OUTPUT = "MASTER_OUTPUT",
@@ -46,6 +48,11 @@ const MODULE_CONFIGS: Record<ModuleType, ModuleConfig> = {
     controlsExtraHeight: 380,
     width: 180,
     controlsComponent: SaturatorControls,
+  },
+  [ModuleType.LFO]: {
+    controlsExtraHeight: 200,
+    width: 180,
+    controlsComponent: LFOControls,
   },
   [ModuleType.MIDI_INPUT]: {
     controlsExtraHeight: 160,

--- a/src/components/patch/ModuleContainer.tsx
+++ b/src/components/patch/ModuleContainer.tsx
@@ -50,7 +50,7 @@ const MODULE_CONFIGS: Record<ModuleType, ModuleConfig> = {
     controlsComponent: SaturatorControls,
   },
   [ModuleType.LFO]: {
-    controlsExtraHeight: 200,
+    controlsExtraHeight: 280,
     width: 180,
     controlsComponent: LFOControls,
   },

--- a/src/components/patch/PatchWorkspace.tsx
+++ b/src/components/patch/PatchWorkspace.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { useAudioContext } from "../../hooks/useAudioContext";
 import { usePatch } from "../../modular/graph/usePatch";
 import { createADSR } from "../../modular/modules/ADSR";
+import { createLFO } from "../../modular/modules/LFO";
 import { createMasterOutput } from "../../modular/modules/MasterOutput";
 import { createMIDIInputTrigger } from "../../modular/modules/MIDIInputTrigger";
 import { createSaturator } from "../../modular/modules/Saturator";
@@ -281,6 +282,14 @@ export const PatchWorkspace: React.FC = () => {
           decay: 0.2,
           sustain: 0.7,
           release: 0.4,
+        });
+        break;
+      case "LFO":
+        created = patch.createModule("LFO", createLFO, {
+          rate: 1.0,
+          depth: 1.0,
+          waveform: "sine",
+          bipolar: true,
         });
         break;
       case "MIDI_INPUT":
@@ -583,6 +592,7 @@ export const PatchWorkspace: React.FC = () => {
               ADD SATURATOR
             </button>
             <button onClick={() => addModuleByType("ADSR")}>ADD ADSR</button>
+            <button onClick={() => addModuleByType("LFO")}>ADD LFO</button>
             <button onClick={() => addModuleByType("MIDI_INPUT")}>
               ADD MIDI IN
             </button>

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -303,6 +303,17 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
           {bipolar ? "-1 to +1" : "0 to +1"}
         </div>
       </div>
+
+      <div className="module-control">
+        <button
+          type="button"
+          className="reset-button"
+          onClick={() => update({ triggerReset: true })}
+          aria-label="Reset LFO phase"
+        >
+          Reset Phase
+        </button>
+      </div>
     </div>
   );
 };

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -13,6 +13,7 @@ import {
   type LfoWaveform,
 } from "../../../utils/lfoUtils";
 import { constrainToRange } from "../../../utils/mathUtils";
+import { LfoWaveformPreview } from "./LfoWaveformPreview";
 
 interface NumberControlProps {
   label: string;
@@ -126,6 +127,15 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
 
   return (
     <div className="module-controls">
+      <div className="lfo-preview-container">
+        <LfoWaveformPreview
+          waveform={waveform}
+          rate={rate}
+          depth={depth}
+          bipolar={bipolar}
+        />
+      </div>
+
       <div className="module-control">
         <label className="module-control-label">Waveform</label>
         <select

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -139,6 +139,9 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
   const [bpm, setBpm] = React.useState<number>(
     typeof initial["bpm"] === "number" ? (initial["bpm"] as number) : LFO_BPM_DEFAULT,
   );
+  const [rateCvAmount, setRateCvAmount] = React.useState<number>(
+    typeof initial["rateCvAmount"] === "number" ? (initial["rateCvAmount"] as number) : 10,
+  );
   const [phaseOffset, setPhaseOffset] = React.useState<number>(
     typeof initial["phaseOffset"] === "number"
       ? constrainLfoPhaseOffset(initial["phaseOffset"] as number)
@@ -281,6 +284,18 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
         onChange={(v) => {
           setDepth(v);
           update({ depth: v });
+        }}
+      />
+
+      <NumberControl
+        label="Rate CV Amt (Hz)"
+        value={rateCvAmount}
+        min={0}
+        max={50}
+        step={0.5}
+        onChange={(v) => {
+          setRateCvAmount(v);
+          update({ rateCvAmount: v });
         }}
       />
 

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -176,6 +176,7 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
           <option value="triangle">Triangle</option>
           <option value="square">Square</option>
           <option value="sawtooth">Sawtooth</option>
+          <option value="sample_hold">S&amp;H</option>
         </select>
       </div>
 

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -1,0 +1,205 @@
+import React from "react";
+
+import type { ModuleInstance } from "../../../modular/types";
+import {
+  constrainLfoDepth,
+  constrainLfoRate,
+  formatLfoRate,
+  LFO_DEPTH_MAXIMUM,
+  LFO_DEPTH_MINIMUM,
+  LFO_RATE_MAXIMUM,
+  LFO_RATE_MINIMUM,
+  LFO_WAVEFORMS,
+  type LfoWaveform,
+} from "../../../utils/lfoUtils";
+import { constrainToRange } from "../../../utils/mathUtils";
+
+interface NumberControlProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  onChange: (next: number) => void;
+  disabled?: boolean;
+  formatDisplay?: (value: number) => string;
+}
+
+const NumberControl: React.FC<NumberControlProps> = ({
+  label,
+  value,
+  min,
+  max,
+  step = 1,
+  onChange,
+  disabled = false,
+  formatDisplay,
+}) => {
+  const [text, setText] = React.useState<string>(() =>
+    formatDisplay ? formatDisplay(value) : String(value),
+  );
+  React.useEffect(() => {
+    setText(formatDisplay ? formatDisplay(value) : String(value));
+  }, [value, formatDisplay]);
+
+  const commit = (raw: string) => {
+    const trimmed = raw.trim();
+    const parsed = Number(trimmed);
+    if (!Number.isFinite(parsed)) {
+      setText(formatDisplay ? formatDisplay(value) : String(value));
+      return;
+    }
+    const clamped = constrainToRange(parsed, min, max);
+    setText(formatDisplay ? formatDisplay(clamped) : String(clamped));
+    onChange(clamped);
+  };
+
+  return (
+    <div className="module-control">
+      <label className="module-control-label">{label}</label>
+      <input
+        className="module-control-input"
+        aria-label={`${label} input`}
+        type="text"
+        inputMode="decimal"
+        value={text}
+        disabled={disabled}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={() => commit(text)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit(text);
+          if (e.key === "Escape")
+            setText(formatDisplay ? formatDisplay(value) : String(value));
+        }}
+      />
+      <div className="module-control-slider-row">
+        <input
+          className="module-control-slider"
+          aria-label={`${label} slider`}
+          type="range"
+          min={min}
+          max={max}
+          step={step}
+          value={value}
+          disabled={disabled}
+          onChange={(e) =>
+            onChange(constrainToRange(Number(e.target.value), min, max))
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+interface LFOControlsProps {
+  module: ModuleInstance;
+}
+
+export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
+  const initial = module.getParams?.() ?? {};
+  const [rate, setRate] = React.useState<number>(
+    typeof initial["rate"] === "number"
+      ? constrainLfoRate(initial["rate"] as number)
+      : 1.0,
+  );
+  const [depth, setDepth] = React.useState<number>(
+    typeof initial["depth"] === "number"
+      ? constrainLfoDepth(initial["depth"] as number)
+      : 1.0,
+  );
+  const [waveform, setWaveform] = React.useState<LfoWaveform>(
+    typeof initial["waveform"] === "string" &&
+      LFO_WAVEFORMS.includes(initial["waveform"] as LfoWaveform)
+      ? (initial["waveform"] as LfoWaveform)
+      : "sine",
+  );
+  const [bipolar, setBipolar] = React.useState<boolean>(
+    typeof initial["bipolar"] === "boolean"
+      ? (initial["bipolar"] as boolean)
+      : true,
+  );
+
+  const update = React.useCallback(
+    (partial: Record<string, unknown>) => module.updateParams?.(partial),
+    [module],
+  );
+
+  return (
+    <div className="module-controls">
+      <div className="module-control">
+        <label className="module-control-label">Waveform</label>
+        <select
+          className="module-control-select"
+          aria-label="Waveform"
+          value={waveform}
+          onChange={(e) => {
+            const next = e.target.value as LfoWaveform;
+            setWaveform(next);
+            update({ waveform: next });
+          }}
+        >
+          <option value="sine">Sine</option>
+          <option value="triangle">Triangle</option>
+          <option value="square">Square</option>
+          <option value="sawtooth">Sawtooth</option>
+        </select>
+      </div>
+
+      <NumberControl
+        label="Rate (Hz)"
+        value={rate}
+        min={LFO_RATE_MINIMUM}
+        max={LFO_RATE_MAXIMUM}
+        step={0.01}
+        formatDisplay={formatLfoRate}
+        onChange={(v) => {
+          setRate(v);
+          update({ rate: v });
+        }}
+      />
+
+      <NumberControl
+        label="Depth"
+        value={depth}
+        min={LFO_DEPTH_MINIMUM}
+        max={LFO_DEPTH_MAXIMUM}
+        step={0.01}
+        onChange={(v) => {
+          setDepth(v);
+          update({ depth: v });
+        }}
+      />
+
+      <div className="module-control">
+        <label className="module-control-label">Output Mode</label>
+        <div className="toggle-button-group">
+          <button
+            type="button"
+            className={`toggle-button ${bipolar ? "active" : ""}`}
+            onClick={() => {
+              setBipolar(true);
+              update({ bipolar: true });
+            }}
+            aria-pressed={bipolar}
+          >
+            Bipolar
+          </button>
+          <button
+            type="button"
+            className={`toggle-button ${!bipolar ? "active" : ""}`}
+            onClick={() => {
+              setBipolar(false);
+              update({ bipolar: false });
+            }}
+            aria-pressed={!bipolar}
+          >
+            Unipolar
+          </button>
+        </div>
+        <div className="module-control-hint">
+          {bipolar ? "-1 to +1" : "0 to +1"}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -2,14 +2,21 @@ import React from "react";
 
 import type { ModuleInstance } from "../../../modular/types";
 import {
+  calculateSyncedRate,
   constrainLfoDepth,
   constrainLfoRate,
   formatLfoRate,
+  LFO_BPM_DEFAULT,
+  LFO_BPM_MAXIMUM,
+  LFO_BPM_MINIMUM,
   LFO_DEPTH_MAXIMUM,
   LFO_DEPTH_MINIMUM,
   LFO_RATE_MAXIMUM,
   LFO_RATE_MINIMUM,
+  LFO_SYNC_DIVISION_DEFAULT,
+  LFO_SYNC_DIVISIONS,
   LFO_WAVEFORMS,
+  type LfoSyncDivision,
   type LfoWaveform,
 } from "../../../utils/lfoUtils";
 import { constrainToRange } from "../../../utils/mathUtils";
@@ -119,18 +126,35 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
       ? (initial["bipolar"] as boolean)
       : true,
   );
+  const [syncEnabled, setSyncEnabled] = React.useState<boolean>(
+    typeof initial["syncEnabled"] === "boolean"
+      ? (initial["syncEnabled"] as boolean)
+      : false,
+  );
+  const [bpm, setBpm] = React.useState<number>(
+    typeof initial["bpm"] === "number" ? (initial["bpm"] as number) : LFO_BPM_DEFAULT,
+  );
+  const [syncDivision, setSyncDivision] = React.useState<LfoSyncDivision>(
+    typeof initial["syncDivision"] === "string" &&
+      LFO_SYNC_DIVISIONS.includes(initial["syncDivision"] as LfoSyncDivision)
+      ? (initial["syncDivision"] as LfoSyncDivision)
+      : LFO_SYNC_DIVISION_DEFAULT,
+  );
 
   const update = React.useCallback(
     (partial: Record<string, unknown>) => module.updateParams?.(partial),
     [module],
   );
 
+  /** Effective rate shown in UI when in sync mode */
+  const effectiveRate = syncEnabled ? calculateSyncedRate(bpm, syncDivision) : rate;
+
   return (
     <div className="module-controls">
       <div className="lfo-preview-container">
         <LfoWaveformPreview
           waveform={waveform}
-          rate={rate}
+          rate={effectiveRate}
           depth={depth}
           bipolar={bipolar}
         />
@@ -155,18 +179,86 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
         </select>
       </div>
 
-      <NumberControl
-        label="Rate (Hz)"
-        value={rate}
-        min={LFO_RATE_MINIMUM}
-        max={LFO_RATE_MAXIMUM}
-        step={0.01}
-        formatDisplay={formatLfoRate}
-        onChange={(v) => {
-          setRate(v);
-          update({ rate: v });
-        }}
-      />
+      <div className="module-control">
+        <label className="module-control-label">Rate Mode</label>
+        <div className="toggle-button-group">
+          <button
+            type="button"
+            className={`toggle-button ${!syncEnabled ? "active" : ""}`}
+            onClick={() => {
+              setSyncEnabled(false);
+              update({ syncEnabled: false });
+            }}
+            aria-pressed={!syncEnabled}
+          >
+            Free
+          </button>
+          <button
+            type="button"
+            className={`toggle-button ${syncEnabled ? "active" : ""}`}
+            onClick={() => {
+              setSyncEnabled(true);
+              update({ syncEnabled: true });
+            }}
+            aria-pressed={syncEnabled}
+          >
+            Sync
+          </button>
+        </div>
+      </div>
+
+      {!syncEnabled && (
+        <NumberControl
+          label="Rate (Hz)"
+          value={rate}
+          min={LFO_RATE_MINIMUM}
+          max={LFO_RATE_MAXIMUM}
+          step={0.01}
+          formatDisplay={formatLfoRate}
+          onChange={(v) => {
+            setRate(v);
+            update({ rate: v });
+          }}
+        />
+      )}
+
+      {syncEnabled && (
+        <>
+          <NumberControl
+            label="BPM"
+            value={bpm}
+            min={LFO_BPM_MINIMUM}
+            max={LFO_BPM_MAXIMUM}
+            step={1}
+            onChange={(v) => {
+              setBpm(v);
+              update({ bpm: v });
+            }}
+          />
+          <div className="module-control">
+            <label className="module-control-label">Division</label>
+            <select
+              className="module-control-select"
+              aria-label="Sync Division"
+              value={syncDivision}
+              onChange={(e) => {
+                const next = e.target.value as LfoSyncDivision;
+                setSyncDivision(next);
+                update({ syncDivision: next });
+              }}
+            >
+              {LFO_SYNC_DIVISIONS.map((div) => (
+                <option key={div} value={div}>
+                  {div}
+                </option>
+              ))}
+            </select>
+            <div className="module-control-hint">
+              {formatLfoRate(calculateSyncedRate(bpm, syncDivision))} Hz
+            </div>
+          </div>
+        </>
+      )}
 
       <NumberControl
         label="Depth"

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -142,6 +142,9 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
   const [rateCvAmount, setRateCvAmount] = React.useState<number>(
     typeof initial["rateCvAmount"] === "number" ? (initial["rateCvAmount"] as number) : 10,
   );
+  const [fadeIn, setFadeIn] = React.useState<number>(
+    typeof initial["fadeIn"] === "number" ? (initial["fadeIn"] as number) : 0,
+  );
   const [phaseOffset, setPhaseOffset] = React.useState<number>(
     typeof initial["phaseOffset"] === "number"
       ? constrainLfoPhaseOffset(initial["phaseOffset"] as number)
@@ -342,6 +345,18 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
           {bipolar ? "-1 to +1" : "0 to +1"}
         </div>
       </div>
+
+      <NumberControl
+        label="Fade-In (s)"
+        value={fadeIn}
+        min={0}
+        max={10}
+        step={0.1}
+        onChange={(v) => {
+          setFadeIn(v);
+          update({ fadeIn: v });
+        }}
+      />
 
       <div className="module-control">
         <button

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -137,10 +137,14 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
       : false,
   );
   const [bpm, setBpm] = React.useState<number>(
-    typeof initial["bpm"] === "number" ? (initial["bpm"] as number) : LFO_BPM_DEFAULT,
+    typeof initial["bpm"] === "number"
+      ? (initial["bpm"] as number)
+      : LFO_BPM_DEFAULT,
   );
   const [rateCvAmount, setRateCvAmount] = React.useState<number>(
-    typeof initial["rateCvAmount"] === "number" ? (initial["rateCvAmount"] as number) : 10,
+    typeof initial["rateCvAmount"] === "number"
+      ? (initial["rateCvAmount"] as number)
+      : 10,
   );
   const [fadeIn, setFadeIn] = React.useState<number>(
     typeof initial["fadeIn"] === "number" ? (initial["fadeIn"] as number) : 0,
@@ -163,7 +167,9 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
   );
 
   /** Effective rate shown in UI when in sync mode */
-  const effectiveRate = syncEnabled ? calculateSyncedRate(bpm, syncDivision) : rate;
+  const effectiveRate = syncEnabled
+    ? calculateSyncedRate(bpm, syncDivision)
+    : rate;
 
   return (
     <div className="module-controls">

--- a/src/components/patch/controls/LFOControls.tsx
+++ b/src/components/patch/controls/LFOControls.tsx
@@ -4,13 +4,18 @@ import type { ModuleInstance } from "../../../modular/types";
 import {
   calculateSyncedRate,
   constrainLfoDepth,
+  constrainLfoPhaseOffset,
   constrainLfoRate,
   formatLfoRate,
+  formatPhaseOffset,
   LFO_BPM_DEFAULT,
   LFO_BPM_MAXIMUM,
   LFO_BPM_MINIMUM,
   LFO_DEPTH_MAXIMUM,
   LFO_DEPTH_MINIMUM,
+  LFO_PHASE_OFFSET_DEFAULT,
+  LFO_PHASE_OFFSET_MAXIMUM,
+  LFO_PHASE_OFFSET_MINIMUM,
   LFO_RATE_MAXIMUM,
   LFO_RATE_MINIMUM,
   LFO_SYNC_DIVISION_DEFAULT,
@@ -134,6 +139,11 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
   const [bpm, setBpm] = React.useState<number>(
     typeof initial["bpm"] === "number" ? (initial["bpm"] as number) : LFO_BPM_DEFAULT,
   );
+  const [phaseOffset, setPhaseOffset] = React.useState<number>(
+    typeof initial["phaseOffset"] === "number"
+      ? constrainLfoPhaseOffset(initial["phaseOffset"] as number)
+      : LFO_PHASE_OFFSET_DEFAULT,
+  );
   const [syncDivision, setSyncDivision] = React.useState<LfoSyncDivision>(
     typeof initial["syncDivision"] === "string" &&
       LFO_SYNC_DIVISIONS.includes(initial["syncDivision"] as LfoSyncDivision)
@@ -157,6 +167,7 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
           rate={effectiveRate}
           depth={depth}
           bipolar={bipolar}
+          phaseOffset={phaseOffset}
         />
       </div>
 
@@ -270,6 +281,19 @@ export const LFOControls: React.FC<LFOControlsProps> = ({ module }) => {
         onChange={(v) => {
           setDepth(v);
           update({ depth: v });
+        }}
+      />
+
+      <NumberControl
+        label="Phase"
+        value={phaseOffset}
+        min={LFO_PHASE_OFFSET_MINIMUM}
+        max={LFO_PHASE_OFFSET_MAXIMUM}
+        step={0.01}
+        formatDisplay={formatPhaseOffset}
+        onChange={(v) => {
+          setPhaseOffset(v);
+          update({ phaseOffset: v });
         }}
       />
 

--- a/src/components/patch/controls/LfoWaveformPreview.tsx
+++ b/src/components/patch/controls/LfoWaveformPreview.tsx
@@ -74,19 +74,14 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
     );
 
     // Compute inverted samples for display
-    // Inverted = signal * -1; for unipolar, reflect around the center (depth/2)
-    const invertedSamples = samples.map((value) => {
-      if (bipolar) {
-        return -value;
-      }
-      // Unipolar: reflect around the center value (depth / 2)
-      const center = depth / 2;
-      return center - (value - center);
-    });
+    // Inverted output uses simple negation (* -1) to match module DSP behavior
+    // In unipolar mode, this produces negative values (-depth..0)
+    const invertedSamples = samples.map((value) => -value);
 
     // Determine the value range for Y-axis mapping
-    const maxAmplitude = bipolar ? depth : depth;
-    const minValue = bipolar ? -maxAmplitude : 0;
+    // When showing inverted, always use bipolar range to accommodate negative inverted values
+    const maxAmplitude = depth;
+    const minValue = showInverted || bipolar ? -maxAmplitude : 0;
     const maxValue = maxAmplitude;
     const valueRange = maxValue - minValue || 1;
 

--- a/src/components/patch/controls/LfoWaveformPreview.tsx
+++ b/src/components/patch/controls/LfoWaveformPreview.tsx
@@ -11,6 +11,7 @@ interface LfoWaveformPreviewProps {
   depth: number;
   bipolar: boolean;
   phaseOffset?: number;
+  showInverted?: boolean;
   width?: number;
   height?: number;
 }
@@ -18,11 +19,17 @@ interface LfoWaveformPreviewProps {
 /** Number of samples used to draw the waveform shape */
 const SAMPLE_COUNT = 128;
 
-/** Color for the waveform line */
+/** Color for the main waveform line */
 const WAVEFORM_COLOR = "#ffb347";
+
+/** Color for the inverted waveform line */
+const INVERTED_WAVEFORM_COLOR = "#47b3ff";
 
 /** Color for the animated phase cursor */
 const CURSOR_COLOR = "#ff6b35";
+
+/** Color for the inverted cursor dot */
+const INVERTED_CURSOR_COLOR = "#47b3ff";
 
 /** Color for the center / zero line */
 const ZERO_LINE_COLOR = "#333";
@@ -43,6 +50,7 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
   depth,
   bipolar,
   phaseOffset = 0,
+  showInverted = true,
   width = 148,
   height = 60,
 }) => {
@@ -64,6 +72,17 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       bipolar,
       phaseOffset,
     );
+
+    // Compute inverted samples for display
+    // Inverted = signal * -1; for unipolar, reflect around the center (depth/2)
+    const invertedSamples = samples.map((value) => {
+      if (bipolar) {
+        return -value;
+      }
+      // Unipolar: reflect around the center value (depth / 2)
+      const center = depth / 2;
+      return center - (value - center);
+    });
 
     // Determine the value range for Y-axis mapping
     const maxAmplitude = bipolar ? depth : depth;
@@ -106,23 +125,36 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       context.stroke();
       context.setLineDash([]);
 
-      // Draw waveform shape
+      /** Draws a waveform path from a sample array */
+      const drawWaveformPath = (sampleArray: number[]) => {
+        context.beginPath();
+        for (let i = 0; i < sampleArray.length; i++) {
+          const x = (i / sampleArray.length) * width;
+          const y = valueToY(sampleArray[i]);
+          if (i === 0) {
+            context.moveTo(x, y);
+          } else {
+            context.lineTo(x, y);
+          }
+        }
+        // Close the loop back to the start for visual continuity
+        context.lineTo(width, valueToY(sampleArray[0]));
+        context.stroke();
+      };
+
+      // Draw inverted waveform first (behind main waveform)
+      if (showInverted) {
+        context.strokeStyle = INVERTED_WAVEFORM_COLOR;
+        context.lineWidth = 1.5;
+        context.globalAlpha = 0.5;
+        drawWaveformPath(invertedSamples);
+        context.globalAlpha = 1;
+      }
+
+      // Draw main waveform shape
       context.strokeStyle = WAVEFORM_COLOR;
       context.lineWidth = 1.5;
-      context.beginPath();
-
-      for (let i = 0; i < samples.length; i++) {
-        const x = (i / samples.length) * width;
-        const y = valueToY(samples[i]);
-        if (i === 0) {
-          context.moveTo(x, y);
-        } else {
-          context.lineTo(x, y);
-        }
-      }
-      // Close the loop back to the start for visual continuity
-      context.lineTo(width, valueToY(samples[0]));
-      context.stroke();
+      drawWaveformPath(samples);
 
       // Draw animated cursor (vertical line at current phase)
       context.strokeStyle = CURSOR_COLOR;
@@ -133,7 +165,7 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       context.lineTo(cursorX, height - verticalPadding);
       context.stroke();
 
-      // Draw a dot at the intersection of cursor and waveform
+      // Draw a dot on the main waveform at cursor position
       const cursorSampleIndex = Math.floor(cursorPhase * samples.length);
       const cursorY = valueToY(
         samples[Math.min(cursorSampleIndex, samples.length - 1)],
@@ -143,6 +175,17 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       context.beginPath();
       context.arc(cursorX, cursorY, 3, 0, Math.PI * 2);
       context.fill();
+
+      // Draw a dot on the inverted waveform at cursor position
+      if (showInverted) {
+        const invertedCursorY = valueToY(
+          invertedSamples[Math.min(cursorSampleIndex, invertedSamples.length - 1)],
+        );
+        context.fillStyle = INVERTED_CURSOR_COLOR;
+        context.beginPath();
+        context.arc(cursorX, invertedCursorY, 2.5, 0, Math.PI * 2);
+        context.fill();
+      }
 
       animationRef.current = requestAnimationFrame(draw);
     };
@@ -155,7 +198,7 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       }
       startTimeRef.current = undefined;
     };
-  }, [waveform, rate, depth, bipolar, phaseOffset, width, height]);
+  }, [waveform, rate, depth, bipolar, phaseOffset, showInverted, width, height]);
 
   return (
     <div className="lfo-waveform-preview">

--- a/src/components/patch/controls/LfoWaveformPreview.tsx
+++ b/src/components/patch/controls/LfoWaveformPreview.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useRef } from "react";
+
+import {
+  generateLfoWaveformSamples,
+  type LfoWaveform,
+} from "../../../utils/lfoUtils";
+
+interface LfoWaveformPreviewProps {
+  waveform: LfoWaveform;
+  rate: number;
+  depth: number;
+  bipolar: boolean;
+  width?: number;
+  height?: number;
+}
+
+/** Number of samples used to draw the waveform shape */
+const SAMPLE_COUNT = 128;
+
+/** Color for the waveform line */
+const WAVEFORM_COLOR = "#ffb347";
+
+/** Color for the animated phase cursor */
+const CURSOR_COLOR = "#ff6b35";
+
+/** Color for the center / zero line */
+const ZERO_LINE_COLOR = "#333";
+
+/** Background color */
+const BACKGROUND_COLOR = "#1a1a1a";
+
+/**
+ * Renders an animated preview of the LFO waveform shape.
+ *
+ * Instead of an AnalyserNode (which shows nearly flat lines at sub-audio LFO
+ * frequencies), this component draws the waveform mathematically and animates
+ * a vertical cursor to indicate the current phase position based on the rate.
+ */
+export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
+  waveform,
+  rate,
+  depth,
+  bipolar,
+  width = 148,
+  height = 60,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number | undefined>(undefined);
+  const startTimeRef = useRef<number | undefined>(undefined);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    const samples = generateLfoWaveformSamples(
+      waveform,
+      SAMPLE_COUNT,
+      depth,
+      bipolar,
+    );
+
+    // Determine the value range for Y-axis mapping
+    const maxAmplitude = bipolar ? depth : depth;
+    const minValue = bipolar ? -maxAmplitude : 0;
+    const maxValue = maxAmplitude;
+    const valueRange = maxValue - minValue || 1;
+
+    // Padding from top/bottom edges
+    const verticalPadding = 4;
+    const drawHeight = height - verticalPadding * 2;
+
+    /** Maps a sample value to canvas Y coordinate */
+    const valueToY = (value: number): number => {
+      const normalized = (value - maxValue) / -valueRange; // 0 at top (max), 1 at bottom (min)
+      return verticalPadding + normalized * drawHeight;
+    };
+
+    const draw = (timestamp: number) => {
+      if (startTimeRef.current === undefined) {
+        startTimeRef.current = timestamp;
+      }
+
+      // Calculate the animated cursor position based on elapsed time and rate
+      const elapsedSeconds = (timestamp - startTimeRef.current) / 1000;
+      const cursorPhase = (elapsedSeconds * rate) % 1;
+      const cursorX = cursorPhase * width;
+
+      // Clear
+      context.fillStyle = BACKGROUND_COLOR;
+      context.fillRect(0, 0, width, height);
+
+      // Draw zero/center line
+      const zeroY = valueToY(0);
+      context.strokeStyle = ZERO_LINE_COLOR;
+      context.lineWidth = 1;
+      context.setLineDash([2, 2]);
+      context.beginPath();
+      context.moveTo(0, zeroY);
+      context.lineTo(width, zeroY);
+      context.stroke();
+      context.setLineDash([]);
+
+      // Draw waveform shape
+      context.strokeStyle = WAVEFORM_COLOR;
+      context.lineWidth = 1.5;
+      context.beginPath();
+
+      for (let i = 0; i < samples.length; i++) {
+        const x = (i / samples.length) * width;
+        const y = valueToY(samples[i]);
+        if (i === 0) {
+          context.moveTo(x, y);
+        } else {
+          context.lineTo(x, y);
+        }
+      }
+      // Close the loop back to the start for visual continuity
+      context.lineTo(width, valueToY(samples[0]));
+      context.stroke();
+
+      // Draw animated cursor (vertical line at current phase)
+      context.strokeStyle = CURSOR_COLOR;
+      context.lineWidth = 1.5;
+      context.globalAlpha = 0.8;
+      context.beginPath();
+      context.moveTo(cursorX, verticalPadding);
+      context.lineTo(cursorX, height - verticalPadding);
+      context.stroke();
+
+      // Draw a dot at the intersection of cursor and waveform
+      const cursorSampleIndex = Math.floor(cursorPhase * samples.length);
+      const cursorY = valueToY(
+        samples[Math.min(cursorSampleIndex, samples.length - 1)],
+      );
+      context.globalAlpha = 1;
+      context.fillStyle = CURSOR_COLOR;
+      context.beginPath();
+      context.arc(cursorX, cursorY, 3, 0, Math.PI * 2);
+      context.fill();
+
+      animationRef.current = requestAnimationFrame(draw);
+    };
+
+    animationRef.current = requestAnimationFrame(draw);
+
+    return () => {
+      if (animationRef.current !== undefined) {
+        cancelAnimationFrame(animationRef.current);
+      }
+      startTimeRef.current = undefined;
+    };
+  }, [waveform, rate, depth, bipolar, width, height]);
+
+  return (
+    <div className="lfo-waveform-preview">
+      <canvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        aria-label={`LFO ${waveform} waveform preview`}
+      />
+    </div>
+  );
+};

--- a/src/components/patch/controls/LfoWaveformPreview.tsx
+++ b/src/components/patch/controls/LfoWaveformPreview.tsx
@@ -179,7 +179,9 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       // Draw a dot on the inverted waveform at cursor position
       if (showInverted) {
         const invertedCursorY = valueToY(
-          invertedSamples[Math.min(cursorSampleIndex, invertedSamples.length - 1)],
+          invertedSamples[
+            Math.min(cursorSampleIndex, invertedSamples.length - 1)
+          ],
         );
         context.fillStyle = INVERTED_CURSOR_COLOR;
         context.beginPath();
@@ -198,7 +200,16 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       }
       startTimeRef.current = undefined;
     };
-  }, [waveform, rate, depth, bipolar, phaseOffset, showInverted, width, height]);
+  }, [
+    waveform,
+    rate,
+    depth,
+    bipolar,
+    phaseOffset,
+    showInverted,
+    width,
+    height,
+  ]);
 
   return (
     <div className="lfo-waveform-preview">

--- a/src/components/patch/controls/LfoWaveformPreview.tsx
+++ b/src/components/patch/controls/LfoWaveformPreview.tsx
@@ -10,6 +10,7 @@ interface LfoWaveformPreviewProps {
   rate: number;
   depth: number;
   bipolar: boolean;
+  phaseOffset?: number;
   width?: number;
   height?: number;
 }
@@ -41,6 +42,7 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
   rate,
   depth,
   bipolar,
+  phaseOffset = 0,
   width = 148,
   height = 60,
 }) => {
@@ -60,6 +62,7 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       SAMPLE_COUNT,
       depth,
       bipolar,
+      phaseOffset,
     );
 
     // Determine the value range for Y-axis mapping
@@ -152,7 +155,7 @@ export const LfoWaveformPreview: React.FC<LfoWaveformPreviewProps> = ({
       }
       startTimeRef.current = undefined;
     };
-  }, [waveform, rate, depth, bipolar, width, height]);
+  }, [waveform, rate, depth, bipolar, phaseOffset, width, height]);
 
   return (
     <div className="lfo-waveform-preview">

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -14,6 +14,15 @@ import {
   type LfoWaveform,
 } from "../../utils/lfoUtils";
 
+/** Default fade-in time in seconds (0 = no fade) */
+const FADE_IN_DEFAULT = 0;
+
+/** Minimum fade-in time */
+const FADE_IN_MINIMUM = 0;
+
+/** Maximum fade-in time in seconds */
+const FADE_IN_MAXIMUM = 10;
+
 /** Default CV modulation range for rate (Hz) */
 const RATE_CV_AMOUNT_DEFAULT = 10;
 
@@ -35,6 +44,7 @@ export interface LFOParams {
   syncDivision?: LfoSyncDivision; // Note division for sync mode
   phaseOffset?: number; // Starting phase (0..1, where 0.5 = 180°)
   rateCvAmount?: number; // CV modulation range for rate (0–50 Hz), default 10
+  fadeIn?: number; // Fade-in / attack time in seconds (0 = instant, max 10)
 }
 
 const ports: PortDefinition[] = [
@@ -115,6 +125,11 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   let currentRateCvAmount = Math.min(
     RATE_CV_AMOUNT_MAXIMUM,
     Math.max(RATE_CV_AMOUNT_MINIMUM, parameters?.rateCvAmount ?? RATE_CV_AMOUNT_DEFAULT),
+  );
+
+  let fadeInTime = Math.min(
+    FADE_IN_MAXIMUM,
+    Math.max(FADE_IN_MINIMUM, parameters?.fadeIn ?? FADE_IN_DEFAULT),
   );
 
   const initialRate = getEffectiveRate();
@@ -203,6 +218,10 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   const unipolarScaleNode = audioContext.createGain();
   unipolarScaleNode.gain.value = isBipolar ? 1 : 0.5;
 
+  // Fade-in gain node: starts at 0 and ramps to 1 over fadeInTime seconds
+  const fadeInGainNode = audioContext.createGain();
+  fadeInGainNode.gain.value = fadeInTime > 0 ? 0 : 1;
+
   // Output summing node
   const outputNode = audioContext.createGain();
   outputNode.gain.value = 1;
@@ -221,7 +240,8 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   sampleHoldSourceNode.connect(sampleHoldRouteGain);
   sampleHoldRouteGain.connect(unipolarScaleNode);
   unipolarScaleNode.connect(depthGainNode);
-  depthGainNode.connect(outputNode);
+  depthGainNode.connect(fadeInGainNode);
+  fadeInGainNode.connect(outputNode);
 
   // DC offset for unipolar mode → Output
   // The offset is scaled by depth for proper unipolar output
@@ -238,11 +258,30 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   let activeOscillatorNode = oscillatorNode;
 
   /**
+   * Starts the fade-in envelope from 0 to 1 over fadeInTime seconds.
+   * If fadeInTime is 0, the gain is set to 1 immediately.
+   */
+  const triggerFadeIn = () => {
+    fadeInGainNode.gain.cancelScheduledValues(audioContext.currentTime);
+    if (fadeInTime > 0) {
+      fadeInGainNode.gain.setValueAtTime(0, audioContext.currentTime);
+      fadeInGainNode.gain.linearRampToValueAtTime(
+        1,
+        audioContext.currentTime + fadeInTime,
+      );
+    } else {
+      fadeInGainNode.gain.setValueAtTime(1, audioContext.currentTime);
+    }
+  };
+
+  /**
    * Resets the LFO phase to zero by recreating the oscillator.
    * Also resets the S&H step index.
    */
   const triggerReset = () => {
     sampleHoldStepIndex = 0;
+
+    triggerFadeIn();
 
     if (currentWaveform === "sample_hold") {
       // For S&H, just restart from step 0
@@ -278,6 +317,9 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   oscillatorNode.start(audioContext.currentTime - initialOffsetSeconds);
   dcOffsetNode.start();
   sampleHoldSourceNode.start();
+
+  // Apply fade-in on startup
+  triggerFadeIn();
 
   const portNodes: ModuleInstance["portNodes"] = {
     cv_out: outputNode,
@@ -432,6 +474,16 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         });
       }
 
+      if (
+        partial["fadeIn"] !== undefined &&
+        typeof partial["fadeIn"] === "number"
+      ) {
+        fadeInTime = Math.min(
+          FADE_IN_MAXIMUM,
+          Math.max(FADE_IN_MINIMUM, partial["fadeIn"]),
+        );
+      }
+
       if (partial["triggerReset"] === true) {
         triggerReset();
       }
@@ -509,6 +561,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         syncDivision: currentSyncDivision,
         phaseOffset: currentPhaseOffset,
         rateCvAmount: currentRateCvAmount,
+        fadeIn: fadeInTime,
       };
     },
     dispose() {
@@ -530,6 +583,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
       }
       activeOscillatorNode.disconnect();
       rateCvGainNode.disconnect();
+      fadeInGainNode.disconnect();
       oscillatorRouteGain.disconnect();
       sampleHoldSourceNode.disconnect();
       sampleHoldRouteGain.disconnect();

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -7,6 +7,7 @@ import {
   LFO_DEPTH_DEFAULT,
   LFO_RATE_DEFAULT,
   LFO_SYNC_DIVISION_DEFAULT,
+  sampleHoldValueForStep,
   type LfoSyncDivision,
   type LfoWaveform,
 } from "../../utils/lfoUtils";
@@ -99,19 +100,67 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   const initialDepth = constrainLfoDepth(
     parameters?.depth ?? LFO_DEPTH_DEFAULT,
   );
-  const initialWaveform: OscillatorType = isValidLfoWaveform(
-    parameters?.waveform ?? "sine",
-  )
-    ? (parameters?.waveform as OscillatorType)
+  const initialWaveformParam = parameters?.waveform ?? "sine";
+  const isSampleHoldWaveform = initialWaveformParam === "sample_hold";
+  const initialOscWaveform: OscillatorType = isValidLfoWaveform(
+    initialWaveformParam,
+  ) && !isSampleHoldWaveform
+    ? (initialWaveformParam as OscillatorType)
     : "sine";
+  let currentWaveform: LfoWaveform = initialWaveformParam;
   let isBipolar = parameters?.bipolar ?? true;
 
-  // Create the LFO oscillator
+  // Create the LFO oscillator (always running, muted when in S&H mode)
   const oscillatorNode = audioContext.createOscillator();
-  oscillatorNode.type = initialWaveform;
+  oscillatorNode.type = initialOscWaveform;
   oscillatorNode.frequency.value = initialRate;
 
-  // Depth control gain node (scales the oscillator output)
+  // Route gain for oscillator: 1 in normal mode, 0 in S&H mode
+  const oscillatorRouteGain = audioContext.createGain();
+  oscillatorRouteGain.gain.value = isSampleHoldWaveform ? 0 : 1;
+
+  // Sample & Hold source node (ConstantSourceNode stepped by timer)
+  const sampleHoldSourceNode = audioContext.createConstantSource();
+  sampleHoldSourceNode.offset.value = 0;
+
+  // Route gain for S&H: 0 in normal mode, 1 in S&H mode
+  const sampleHoldRouteGain = audioContext.createGain();
+  sampleHoldRouteGain.gain.value = isSampleHoldWaveform ? 1 : 0;
+
+  // S&H step state
+  let sampleHoldStepIndex = 0;
+  let sampleHoldTimerId: ReturnType<typeof setInterval> | null = null;
+
+  const updateSampleHoldValue = () => {
+    sampleHoldSourceNode.offset.setValueAtTime(
+      sampleHoldValueForStep(sampleHoldStepIndex),
+      audioContext.currentTime,
+    );
+    sampleHoldStepIndex += 1;
+  };
+
+  const startSampleHoldTimer = () => {
+    if (sampleHoldTimerId !== null) {
+      clearInterval(sampleHoldTimerId);
+    }
+    const rateHz = oscillatorNode.frequency.value;
+    const intervalMs = (1 / rateHz) * 1000;
+    updateSampleHoldValue(); // Set initial value immediately
+    sampleHoldTimerId = setInterval(updateSampleHoldValue, intervalMs);
+  };
+
+  const stopSampleHoldTimer = () => {
+    if (sampleHoldTimerId !== null) {
+      clearInterval(sampleHoldTimerId);
+      sampleHoldTimerId = null;
+    }
+  };
+
+  if (isSampleHoldWaveform) {
+    startSampleHoldTimer();
+  }
+
+  // Depth control gain node (scales the mixed oscillator/S&H output)
   const depthGainNode = audioContext.createGain();
   depthGainNode.gain.value = initialDepth;
 
@@ -139,8 +188,11 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   invertedOutputNode.gain.value = 1;
 
   // Connect the signal chain
-  // Oscillator → Unipolar Scale → Depth → Output
-  oscillatorNode.connect(unipolarScaleNode);
+  // (Oscillator → OscRoute + S&H → S&HRoute) → Unipolar Scale → Depth → Output
+  oscillatorNode.connect(oscillatorRouteGain);
+  oscillatorRouteGain.connect(unipolarScaleNode);
+  sampleHoldSourceNode.connect(sampleHoldRouteGain);
+  sampleHoldRouteGain.connect(unipolarScaleNode);
   unipolarScaleNode.connect(depthGainNode);
   depthGainNode.connect(outputNode);
 
@@ -158,6 +210,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   // Start the oscillator and DC offset
   oscillatorNode.start();
   dcOffsetNode.start();
+  sampleHoldSourceNode.start();
 
   const portNodes: ModuleInstance["portNodes"] = {
     cv_out: outputNode,
@@ -312,10 +365,34 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         typeof partial["waveform"] === "string"
       ) {
         if (isValidLfoWaveform(partial["waveform"])) {
-          try {
-            oscillatorNode.type = partial["waveform"] as OscillatorType;
-          } catch {
-            /* ignore invalid */
+          const nextWaveform = partial["waveform"] as LfoWaveform;
+          const wasHold = currentWaveform === "sample_hold";
+          const isNowHold = nextWaveform === "sample_hold";
+          currentWaveform = nextWaveform;
+
+          if (isNowHold && !wasHold) {
+            // Switch to S&H: silence oscillator, activate S&H source
+            oscillatorRouteGain.gain.setValueAtTime(0, audioContext.currentTime);
+            sampleHoldRouteGain.gain.setValueAtTime(1, audioContext.currentTime);
+            sampleHoldStepIndex = 0;
+            startSampleHoldTimer();
+          } else if (!isNowHold && wasHold) {
+            // Switch from S&H: activate oscillator, silence S&H source
+            stopSampleHoldTimer();
+            oscillatorRouteGain.gain.setValueAtTime(1, audioContext.currentTime);
+            sampleHoldRouteGain.gain.setValueAtTime(0, audioContext.currentTime);
+            try {
+              oscillatorNode.type = nextWaveform as OscillatorType;
+            } catch {
+              /* ignore invalid */
+            }
+          } else if (!isNowHold) {
+            // Normal waveform change
+            try {
+              oscillatorNode.type = nextWaveform as OscillatorType;
+            } catch {
+              /* ignore invalid */
+            }
           }
         }
       }
@@ -331,7 +408,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
       return {
         rate: oscillatorNode.frequency.value,
         depth: depthGainNode.gain.value,
-        waveform: oscillatorNode.type,
+        waveform: currentWaveform,
         bipolar: isBipolar,
         syncEnabled: isSyncEnabled,
         bpm: currentBpm,
@@ -339,6 +416,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
       };
     },
     dispose() {
+      stopSampleHoldTimer();
       try {
         oscillatorNode.stop();
       } catch {
@@ -349,7 +427,15 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
       } catch {
         /* already stopped */
       }
+      try {
+        sampleHoldSourceNode.stop();
+      } catch {
+        /* already stopped */
+      }
       oscillatorNode.disconnect();
+      oscillatorRouteGain.disconnect();
+      sampleHoldSourceNode.disconnect();
+      sampleHoldRouteGain.disconnect();
       unipolarScaleNode.disconnect();
       depthGainNode.disconnect();
       dcOffsetNode.disconnect();

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -13,6 +13,15 @@ import {
   type LfoSyncDivision,
   type LfoWaveform,
 } from "../../utils/lfoUtils";
+
+/** Default CV modulation range for rate (Hz) */
+const RATE_CV_AMOUNT_DEFAULT = 10;
+
+/** Minimum CV modulation range for rate */
+const RATE_CV_AMOUNT_MINIMUM = 0;
+
+/** Maximum CV modulation range for rate */
+const RATE_CV_AMOUNT_MAXIMUM = 50;
 import type { CreateModuleFn, ModuleInstance, PortDefinition } from "../types";
 import { smoothParam } from "../utils/smoothing";
 
@@ -25,6 +34,7 @@ export interface LFOParams {
   bpm?: number; // Tempo in BPM (20-300), used when syncEnabled is true
   syncDivision?: LfoSyncDivision; // Note division for sync mode
   phaseOffset?: number; // Starting phase (0..1, where 0.5 = 180°)
+  rateCvAmount?: number; // CV modulation range for rate (0–50 Hz), default 10
 }
 
 const ports: PortDefinition[] = [
@@ -54,7 +64,7 @@ const ports: PortDefinition[] = [
     direction: "in",
     signal: "CV",
     metadata: {
-      description: "Rate modulation input (future)",
+      description: "Rate CV modulation input (CV × rateCvAmount added to base rate)",
     },
   },
   {
@@ -102,6 +112,11 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
     return constrainLfoRate(parameters?.rate ?? LFO_RATE_DEFAULT);
   };
 
+  let currentRateCvAmount = Math.min(
+    RATE_CV_AMOUNT_MAXIMUM,
+    Math.max(RATE_CV_AMOUNT_MINIMUM, parameters?.rateCvAmount ?? RATE_CV_AMOUNT_DEFAULT),
+  );
+
   const initialRate = getEffectiveRate();
   const initialDepth = constrainLfoDepth(
     parameters?.depth ?? LFO_DEPTH_DEFAULT,
@@ -120,6 +135,12 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   const oscillatorNode = audioContext.createOscillator();
   oscillatorNode.type = initialOscWaveform;
   oscillatorNode.frequency.value = initialRate;
+
+  // Rate CV modulation: incoming CV (-1..+1) × rateCvAmount → added to oscillator frequency
+  const rateCvGainNode = audioContext.createGain();
+  rateCvGainNode.gain.value = currentRateCvAmount;
+  // rateCvGainNode output is connected to oscillatorNode.frequency (AudioParam)
+  rateCvGainNode.connect(oscillatorNode.frequency);
 
   // Route gain for oscillator: 1 in normal mode, 0 in S&H mode
   const oscillatorRouteGain = audioContext.createGain();
@@ -242,14 +263,13 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
     newOscillator.type = oldOscillator.type;
     newOscillator.frequency.value = oldOscillator.frequency.value;
     newOscillator.connect(oscillatorRouteGain);
+    // Reconnect rate CV gain to the new oscillator frequency
+    rateCvGainNode.connect(newOscillator.frequency);
     // Apply phase offset: start slightly in the past so the current phase matches offset
     const rateHz = newOscillator.frequency.value;
     const offsetSeconds = rateHz > 0 ? currentPhaseOffset / rateHz : 0;
     newOscillator.start(audioContext.currentTime - offsetSeconds);
     activeOscillatorNode = newOscillator;
-
-    // Update portNodes rate_cv reference to point to new oscillator frequency
-    portNodes.rate_cv = newOscillator.frequency;
   };
 
   // Start the oscillator with phase offset (start in the past to simulate phase offset)
@@ -262,8 +282,8 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   const portNodes: ModuleInstance["portNodes"] = {
     cv_out: outputNode,
     inverted_cv_out: invertedOutputNode,
-    rate_cv: oscillatorNode.frequency, // Future: modulate rate
-    reset: undefined, // Future: reset trigger
+    rate_cv: rateCvGainNode, // CV input for rate modulation
+    reset: undefined,
   };
 
   /**
@@ -398,6 +418,20 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         triggerReset();
       }
 
+      if (
+        partial["rateCvAmount"] !== undefined &&
+        typeof partial["rateCvAmount"] === "number"
+      ) {
+        currentRateCvAmount = Math.min(
+          RATE_CV_AMOUNT_MAXIMUM,
+          Math.max(RATE_CV_AMOUNT_MINIMUM, partial["rateCvAmount"]),
+        );
+        smoothParam(audioContext, rateCvGainNode.gain, currentRateCvAmount, {
+          mode: "linear",
+          time: 0.02,
+        });
+      }
+
       if (partial["triggerReset"] === true) {
         triggerReset();
       }
@@ -474,6 +508,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         bpm: currentBpm,
         syncDivision: currentSyncDivision,
         phaseOffset: currentPhaseOffset,
+        rateCvAmount: currentRateCvAmount,
       };
     },
     dispose() {
@@ -494,6 +529,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         /* already stopped */
       }
       activeOscillatorNode.disconnect();
+      rateCvGainNode.disconnect();
       oscillatorRouteGain.disconnect();
       sampleHoldSourceNode.disconnect();
       sampleHoldRouteGain.disconnect();

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -1,10 +1,12 @@
 import {
   calculateSyncedRate,
   constrainLfoDepth,
+  constrainLfoPhaseOffset,
   constrainLfoRate,
   isValidLfoWaveform,
   LFO_BPM_DEFAULT,
   LFO_DEPTH_DEFAULT,
+  LFO_PHASE_OFFSET_DEFAULT,
   LFO_RATE_DEFAULT,
   LFO_SYNC_DIVISION_DEFAULT,
   sampleHoldValueForStep,
@@ -22,6 +24,7 @@ export interface LFOParams {
   syncEnabled?: boolean; // If true, rate is derived from bpm + syncDivision
   bpm?: number; // Tempo in BPM (20-300), used when syncEnabled is true
   syncDivision?: LfoSyncDivision; // Note division for sync mode
+  phaseOffset?: number; // Starting phase (0..1, where 0.5 = 180°)
 }
 
 const ports: PortDefinition[] = [
@@ -84,6 +87,9 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   const { audioContext, moduleId } = context;
 
   // Default parameters
+  let currentPhaseOffset = constrainLfoPhaseOffset(
+    parameters?.phaseOffset ?? LFO_PHASE_OFFSET_DEFAULT,
+  );
   let isSyncEnabled = parameters?.syncEnabled ?? false;
   let currentBpm = parameters?.bpm ?? LFO_BPM_DEFAULT;
   let currentSyncDivision: LfoSyncDivision =
@@ -236,15 +242,20 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
     newOscillator.type = oldOscillator.type;
     newOscillator.frequency.value = oldOscillator.frequency.value;
     newOscillator.connect(oscillatorRouteGain);
-    newOscillator.start();
+    // Apply phase offset: start slightly in the past so the current phase matches offset
+    const rateHz = newOscillator.frequency.value;
+    const offsetSeconds = rateHz > 0 ? currentPhaseOffset / rateHz : 0;
+    newOscillator.start(audioContext.currentTime - offsetSeconds);
     activeOscillatorNode = newOscillator;
 
     // Update portNodes rate_cv reference to point to new oscillator frequency
     portNodes.rate_cv = newOscillator.frequency;
   };
 
-  // Start the oscillator and DC offset
-  oscillatorNode.start();
+  // Start the oscillator with phase offset (start in the past to simulate phase offset)
+  const initialOffsetSeconds =
+    initialRate > 0 ? currentPhaseOffset / initialRate : 0;
+  oscillatorNode.start(audioContext.currentTime - initialOffsetSeconds);
   dcOffsetNode.start();
   sampleHoldSourceNode.start();
 
@@ -378,6 +389,15 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         });
       }
 
+      if (
+        partial["phaseOffset"] !== undefined &&
+        typeof partial["phaseOffset"] === "number"
+      ) {
+        currentPhaseOffset = constrainLfoPhaseOffset(partial["phaseOffset"]);
+        // Apply immediately via reset
+        triggerReset();
+      }
+
       if (partial["triggerReset"] === true) {
         triggerReset();
       }
@@ -453,6 +473,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         syncEnabled: isSyncEnabled,
         bpm: currentBpm,
         syncDivision: currentSyncDivision,
+        phaseOffset: currentPhaseOffset,
       };
     },
     dispose() {

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -207,6 +207,42 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   outputNode.connect(invertedGainNode);
   invertedGainNode.connect(invertedOutputNode);
 
+  // Mutable reference so it can be replaced on reset
+  let activeOscillatorNode = oscillatorNode;
+
+  /**
+   * Resets the LFO phase to zero by recreating the oscillator.
+   * Also resets the S&H step index.
+   */
+  const triggerReset = () => {
+    sampleHoldStepIndex = 0;
+
+    if (currentWaveform === "sample_hold") {
+      // For S&H, just restart from step 0
+      startSampleHoldTimer();
+      return;
+    }
+
+    // Recreate the oscillator to reset phase
+    const oldOscillator = activeOscillatorNode;
+    try {
+      oldOscillator.stop();
+    } catch {
+      /* already stopped */
+    }
+    oldOscillator.disconnect();
+
+    const newOscillator = audioContext.createOscillator();
+    newOscillator.type = oldOscillator.type;
+    newOscillator.frequency.value = oldOscillator.frequency.value;
+    newOscillator.connect(oscillatorRouteGain);
+    newOscillator.start();
+    activeOscillatorNode = newOscillator;
+
+    // Update portNodes rate_cv reference to point to new oscillator frequency
+    portNodes.rate_cv = newOscillator.frequency;
+  };
+
   // Start the oscillator and DC offset
   oscillatorNode.start();
   dcOffsetNode.start();
@@ -324,7 +360,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         partial["syncDivision"] !== undefined
       ) {
         const syncedRate = getEffectiveRate();
-        smoothParam(audioContext, oscillatorNode.frequency, syncedRate, {
+        smoothParam(audioContext, activeOscillatorNode.frequency, syncedRate, {
           mode: "setTarget",
           timeConstant: 0.05,
         });
@@ -336,10 +372,14 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         !isSyncEnabled
       ) {
         const nextRate = constrainLfoRate(partial["rate"]);
-        smoothParam(audioContext, oscillatorNode.frequency, nextRate, {
+        smoothParam(audioContext, activeOscillatorNode.frequency, nextRate, {
           mode: "setTarget",
           timeConstant: 0.05,
         });
+      }
+
+      if (partial["triggerReset"] === true) {
+        triggerReset();
       }
 
       if (
@@ -382,14 +422,14 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
             oscillatorRouteGain.gain.setValueAtTime(1, audioContext.currentTime);
             sampleHoldRouteGain.gain.setValueAtTime(0, audioContext.currentTime);
             try {
-              oscillatorNode.type = nextWaveform as OscillatorType;
+              activeOscillatorNode.type = nextWaveform as OscillatorType;
             } catch {
               /* ignore invalid */
             }
           } else if (!isNowHold) {
             // Normal waveform change
             try {
-              oscillatorNode.type = nextWaveform as OscillatorType;
+              activeOscillatorNode.type = nextWaveform as OscillatorType;
             } catch {
               /* ignore invalid */
             }
@@ -406,7 +446,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
     },
     getParams() {
       return {
-        rate: oscillatorNode.frequency.value,
+        rate: activeOscillatorNode.frequency.value,
         depth: depthGainNode.gain.value,
         waveform: currentWaveform,
         bipolar: isBipolar,
@@ -418,7 +458,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
     dispose() {
       stopSampleHoldTimer();
       try {
-        oscillatorNode.stop();
+        activeOscillatorNode.stop();
       } catch {
         /* already stopped */
       }
@@ -432,7 +472,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
       } catch {
         /* already stopped */
       }
-      oscillatorNode.disconnect();
+      activeOscillatorNode.disconnect();
       oscillatorRouteGain.disconnect();
       sampleHoldSourceNode.disconnect();
       sampleHoldRouteGain.disconnect();

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -1,0 +1,306 @@
+import {
+  constrainLfoDepth,
+  constrainLfoRate,
+  isValidLfoWaveform,
+  LFO_DEPTH_DEFAULT,
+  LFO_RATE_DEFAULT,
+  type LfoWaveform,
+} from "../../utils/lfoUtils";
+import type { CreateModuleFn, ModuleInstance, PortDefinition } from "../types";
+import { smoothParam } from "../utils/smoothing";
+
+export interface LFOParams {
+  rate: number; // Hz (0.01 to 50)
+  depth: number; // 0 to 1
+  waveform: LfoWaveform;
+  bipolar: boolean; // true = -1..+1, false = 0..+1
+}
+
+const ports: PortDefinition[] = [
+  {
+    id: "cv_out",
+    label: "CV Out",
+    direction: "out",
+    signal: "CV",
+    metadata: {
+      bipolar: true,
+      description: "Main LFO output signal",
+    },
+  },
+  {
+    id: "inverted_cv_out",
+    label: "Inv CV",
+    direction: "out",
+    signal: "CV",
+    metadata: {
+      bipolar: true,
+      description: "Inverted LFO output (180° phase)",
+    },
+  },
+  {
+    id: "rate_cv",
+    label: "Rate CV",
+    direction: "in",
+    signal: "CV",
+    metadata: {
+      description: "Rate modulation input (future)",
+    },
+  },
+  {
+    id: "reset",
+    label: "Reset",
+    direction: "in",
+    signal: "TRIGGER",
+    metadata: {
+      description: "Reset LFO phase (future)",
+    },
+  },
+];
+
+/**
+ * Creates an LFO (Low Frequency Oscillator) module for modulating parameters.
+ *
+ * The LFO generates a low-frequency waveform that can be connected to CV inputs
+ * on other modules for modulation effects (vibrato, tremolo, filter sweeps, etc.).
+ *
+ * Signal chain:
+ * - Oscillator → Depth Gain → Output (bipolar: -1..+1)
+ * - For unipolar output: scaled and offset to 0..+1
+ * - Inverted output: Phase-inverted version of main output
+ *
+ * @param context - Audio module context containing audioContext and moduleId
+ * @param parameters - Initial LFO parameters
+ * @returns ModuleInstance for the LFO
+ */
+export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
+  const { audioContext, moduleId } = context;
+
+  // Default parameters
+  const initialRate = constrainLfoRate(parameters?.rate ?? LFO_RATE_DEFAULT);
+  const initialDepth = constrainLfoDepth(
+    parameters?.depth ?? LFO_DEPTH_DEFAULT,
+  );
+  const initialWaveform: OscillatorType = isValidLfoWaveform(
+    parameters?.waveform ?? "sine",
+  )
+    ? (parameters?.waveform as OscillatorType)
+    : "sine";
+  let isBipolar = parameters?.bipolar ?? true;
+
+  // Create the LFO oscillator
+  const oscillatorNode = audioContext.createOscillator();
+  oscillatorNode.type = initialWaveform;
+  oscillatorNode.frequency.value = initialRate;
+
+  // Depth control gain node (scales the oscillator output)
+  const depthGainNode = audioContext.createGain();
+  depthGainNode.gain.value = initialDepth;
+
+  // For unipolar mode, we need to add a DC offset
+  // Bipolar: oscillator output is -1..+1, multiplied by depth
+  // Unipolar: we need to shift this to 0..+1
+  // We use a ConstantSource for the DC offset
+  const dcOffsetNode = audioContext.createConstantSource();
+  dcOffsetNode.offset.value = isBipolar ? 0 : 0.5; // 0.5 shifts center from 0 to 0.5
+
+  // For unipolar, we also need to halve the oscillator amplitude
+  // so that (osc * 0.5 * depth) + (0.5 * depth) ranges from 0 to depth
+  const unipolarScaleNode = audioContext.createGain();
+  unipolarScaleNode.gain.value = isBipolar ? 1 : 0.5;
+
+  // Output summing node
+  const outputNode = audioContext.createGain();
+  outputNode.gain.value = 1;
+
+  // Inverted output node (multiplies signal by -1)
+  const invertedGainNode = audioContext.createGain();
+  invertedGainNode.gain.value = -1;
+
+  const invertedOutputNode = audioContext.createGain();
+  invertedOutputNode.gain.value = 1;
+
+  // Connect the signal chain
+  // Oscillator → Unipolar Scale → Depth → Output
+  oscillatorNode.connect(unipolarScaleNode);
+  unipolarScaleNode.connect(depthGainNode);
+  depthGainNode.connect(outputNode);
+
+  // DC offset for unipolar mode → Output
+  // The offset is scaled by depth for proper unipolar output
+  const dcScaleNode = audioContext.createGain();
+  dcScaleNode.gain.value = isBipolar ? 0 : initialDepth;
+  dcOffsetNode.connect(dcScaleNode);
+  dcScaleNode.connect(outputNode);
+
+  // Inverted output
+  outputNode.connect(invertedGainNode);
+  invertedGainNode.connect(invertedOutputNode);
+
+  // Start the oscillator and DC offset
+  oscillatorNode.start();
+  dcOffsetNode.start();
+
+  const portNodes: ModuleInstance["portNodes"] = {
+    cv_out: outputNode,
+    inverted_cv_out: invertedOutputNode,
+    rate_cv: oscillatorNode.frequency, // Future: modulate rate
+    reset: undefined, // Future: reset trigger
+  };
+
+  /**
+   * Updates the output configuration for bipolar/unipolar mode
+   */
+  const updateBipolarMode = (bipolar: boolean) => {
+    isBipolar = bipolar;
+    const currentDepth = depthGainNode.gain.value;
+
+    if (bipolar) {
+      // Bipolar: full oscillator range, no DC offset
+      smoothParam(audioContext, unipolarScaleNode.gain, 1, {
+        mode: "linear",
+        time: 0.02,
+      });
+      smoothParam(audioContext, dcScaleNode.gain, 0, {
+        mode: "linear",
+        time: 0.02,
+      });
+    } else {
+      // Unipolar: halve oscillator, add DC offset scaled by depth
+      smoothParam(audioContext, unipolarScaleNode.gain, 0.5, {
+        mode: "linear",
+        time: 0.02,
+      });
+      smoothParam(audioContext, dcScaleNode.gain, currentDepth, {
+        mode: "linear",
+        time: 0.02,
+      });
+    }
+  };
+
+  console.log(`[LFO ${moduleId}] Created with:`, {
+    rate: initialRate,
+    depth: initialDepth,
+    waveform: initialWaveform,
+    bipolar: isBipolar,
+  });
+
+  const instance: ModuleInstance = {
+    id: moduleId,
+    type: "LFO",
+    label: `LFO ${moduleId}`,
+    ports,
+    audioOut: outputNode, // Primary output for convenience
+    portNodes,
+    connect(fromPortId, target) {
+      const fromConnectionNode = portNodes[fromPortId];
+      const toConnectionEntity = target.module.portNodes[target.portId];
+      if (!fromConnectionNode || !toConnectionEntity) return;
+
+      console.log(
+        `[LFO ${moduleId}] Connecting from ${fromPortId} to ${target.module.id}.${target.portId}`,
+        {
+          fromNode: fromConnectionNode,
+          toEntity: toConnectionEntity,
+        },
+      );
+
+      if (
+        fromConnectionNode instanceof AudioNode &&
+        toConnectionEntity instanceof AudioNode
+      ) {
+        fromConnectionNode.connect(toConnectionEntity);
+        console.log(
+          `[LFO ${moduleId}] ✓ AudioNode → AudioNode connection made`,
+        );
+      } else if (
+        fromConnectionNode instanceof AudioNode &&
+        toConnectionEntity instanceof AudioParam
+      ) {
+        fromConnectionNode.connect(toConnectionEntity);
+        console.log(
+          `[LFO ${moduleId}] ✓ AudioNode → AudioParam connection made`,
+        );
+      }
+    },
+    updateParams(partial) {
+      if (
+        partial["rate"] !== undefined &&
+        typeof partial["rate"] === "number"
+      ) {
+        const nextRate = constrainLfoRate(partial["rate"]);
+        smoothParam(audioContext, oscillatorNode.frequency, nextRate, {
+          mode: "setTarget",
+          timeConstant: 0.05,
+        });
+      }
+
+      if (
+        partial["depth"] !== undefined &&
+        typeof partial["depth"] === "number"
+      ) {
+        const nextDepth = constrainLfoDepth(partial["depth"]);
+        smoothParam(audioContext, depthGainNode.gain, nextDepth, {
+          mode: "linear",
+          time: 0.02,
+        });
+        // Also update DC scale if in unipolar mode
+        if (!isBipolar) {
+          smoothParam(audioContext, dcScaleNode.gain, nextDepth, {
+            mode: "linear",
+            time: 0.02,
+          });
+        }
+      }
+
+      if (
+        partial["waveform"] !== undefined &&
+        typeof partial["waveform"] === "string"
+      ) {
+        if (isValidLfoWaveform(partial["waveform"])) {
+          try {
+            oscillatorNode.type = partial["waveform"] as OscillatorType;
+          } catch {
+            /* ignore invalid */
+          }
+        }
+      }
+
+      if (
+        partial["bipolar"] !== undefined &&
+        typeof partial["bipolar"] === "boolean"
+      ) {
+        updateBipolarMode(partial["bipolar"]);
+      }
+    },
+    getParams() {
+      return {
+        rate: oscillatorNode.frequency.value,
+        depth: depthGainNode.gain.value,
+        waveform: oscillatorNode.type,
+        bipolar: isBipolar,
+      };
+    },
+    dispose() {
+      try {
+        oscillatorNode.stop();
+      } catch {
+        /* already stopped */
+      }
+      try {
+        dcOffsetNode.stop();
+      } catch {
+        /* already stopped */
+      }
+      oscillatorNode.disconnect();
+      unipolarScaleNode.disconnect();
+      depthGainNode.disconnect();
+      dcOffsetNode.disconnect();
+      dcScaleNode.disconnect();
+      outputNode.disconnect();
+      invertedGainNode.disconnect();
+      invertedOutputNode.disconnect();
+    },
+  };
+
+  return instance;
+};

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -361,7 +361,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   console.log(`[LFO ${moduleId}] Created with:`, {
     rate: initialRate,
     depth: initialDepth,
-    waveform: initialWaveform,
+    waveform: currentWaveform,
     bipolar: isBipolar,
   });
 

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -1,19 +1,26 @@
 import {
+  calculateSyncedRate,
   constrainLfoDepth,
   constrainLfoRate,
   isValidLfoWaveform,
+  LFO_BPM_DEFAULT,
   LFO_DEPTH_DEFAULT,
   LFO_RATE_DEFAULT,
+  LFO_SYNC_DIVISION_DEFAULT,
+  type LfoSyncDivision,
   type LfoWaveform,
 } from "../../utils/lfoUtils";
 import type { CreateModuleFn, ModuleInstance, PortDefinition } from "../types";
 import { smoothParam } from "../utils/smoothing";
 
 export interface LFOParams {
-  rate: number; // Hz (0.01 to 50)
-  depth: number; // 0 to 1
-  waveform: LfoWaveform;
-  bipolar: boolean; // true = -1..+1, false = 0..+1
+  rate?: number; // Hz (0.01 to 50), used when syncEnabled is false
+  depth?: number; // 0 to 1
+  waveform?: LfoWaveform;
+  bipolar?: boolean; // true = -1..+1, false = 0..+1
+  syncEnabled?: boolean; // If true, rate is derived from bpm + syncDivision
+  bpm?: number; // Tempo in BPM (20-300), used when syncEnabled is true
+  syncDivision?: LfoSyncDivision; // Note division for sync mode
 }
 
 const ports: PortDefinition[] = [
@@ -76,7 +83,19 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   const { audioContext, moduleId } = context;
 
   // Default parameters
-  const initialRate = constrainLfoRate(parameters?.rate ?? LFO_RATE_DEFAULT);
+  let isSyncEnabled = parameters?.syncEnabled ?? false;
+  let currentBpm = parameters?.bpm ?? LFO_BPM_DEFAULT;
+  let currentSyncDivision: LfoSyncDivision =
+    parameters?.syncDivision ?? LFO_SYNC_DIVISION_DEFAULT;
+
+  const getEffectiveRate = (): number => {
+    if (isSyncEnabled) {
+      return constrainLfoRate(calculateSyncedRate(currentBpm, currentSyncDivision));
+    }
+    return constrainLfoRate(parameters?.rate ?? LFO_RATE_DEFAULT);
+  };
+
+  const initialRate = getEffectiveRate();
   const initialDepth = constrainLfoDepth(
     parameters?.depth ?? LFO_DEPTH_DEFAULT,
   );
@@ -223,9 +242,45 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
       }
     },
     updateParams(partial) {
+      // Handle sync parameters first so rate update reflects current sync state
+      if (
+        partial["syncEnabled"] !== undefined &&
+        typeof partial["syncEnabled"] === "boolean"
+      ) {
+        isSyncEnabled = partial["syncEnabled"];
+      }
+
+      if (
+        partial["bpm"] !== undefined &&
+        typeof partial["bpm"] === "number"
+      ) {
+        currentBpm = partial["bpm"];
+      }
+
+      if (
+        partial["syncDivision"] !== undefined &&
+        typeof partial["syncDivision"] === "string"
+      ) {
+        currentSyncDivision = partial["syncDivision"] as LfoSyncDivision;
+      }
+
+      // If any sync-related param changed, recompute the rate
+      if (
+        partial["syncEnabled"] !== undefined ||
+        partial["bpm"] !== undefined ||
+        partial["syncDivision"] !== undefined
+      ) {
+        const syncedRate = getEffectiveRate();
+        smoothParam(audioContext, oscillatorNode.frequency, syncedRate, {
+          mode: "setTarget",
+          timeConstant: 0.05,
+        });
+      }
+
       if (
         partial["rate"] !== undefined &&
-        typeof partial["rate"] === "number"
+        typeof partial["rate"] === "number" &&
+        !isSyncEnabled
       ) {
         const nextRate = constrainLfoRate(partial["rate"]);
         smoothParam(audioContext, oscillatorNode.frequency, nextRate, {
@@ -278,6 +333,9 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         depth: depthGainNode.gain.value,
         waveform: oscillatorNode.type,
         bipolar: isBipolar,
+        syncEnabled: isSyncEnabled,
+        bpm: currentBpm,
+        syncDivision: currentSyncDivision,
       };
     },
     dispose() {

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -9,9 +9,9 @@ import {
   LFO_PHASE_OFFSET_DEFAULT,
   LFO_RATE_DEFAULT,
   LFO_SYNC_DIVISION_DEFAULT,
-  sampleHoldValueForStep,
   type LfoSyncDivision,
   type LfoWaveform,
+  sampleHoldValueForStep,
 } from "../../utils/lfoUtils";
 
 /** Default fade-in time in seconds (0 = no fade) */
@@ -74,7 +74,8 @@ const ports: PortDefinition[] = [
     direction: "in",
     signal: "CV",
     metadata: {
-      description: "Rate CV modulation input (CV × rateCvAmount added to base rate)",
+      description:
+        "Rate CV modulation input (CV × rateCvAmount added to base rate)",
     },
   },
   {
@@ -117,14 +118,19 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
 
   const getEffectiveRate = (): number => {
     if (isSyncEnabled) {
-      return constrainLfoRate(calculateSyncedRate(currentBpm, currentSyncDivision));
+      return constrainLfoRate(
+        calculateSyncedRate(currentBpm, currentSyncDivision),
+      );
     }
     return constrainLfoRate(parameters?.rate ?? LFO_RATE_DEFAULT);
   };
 
   let currentRateCvAmount = Math.min(
     RATE_CV_AMOUNT_MAXIMUM,
-    Math.max(RATE_CV_AMOUNT_MINIMUM, parameters?.rateCvAmount ?? RATE_CV_AMOUNT_DEFAULT),
+    Math.max(
+      RATE_CV_AMOUNT_MINIMUM,
+      parameters?.rateCvAmount ?? RATE_CV_AMOUNT_DEFAULT,
+    ),
   );
 
   let fadeInTime = Math.min(
@@ -138,11 +144,10 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   );
   const initialWaveformParam = parameters?.waveform ?? "sine";
   const isSampleHoldWaveform = initialWaveformParam === "sample_hold";
-  const initialOscWaveform: OscillatorType = isValidLfoWaveform(
-    initialWaveformParam,
-  ) && !isSampleHoldWaveform
-    ? (initialWaveformParam as OscillatorType)
-    : "sine";
+  const initialOscWaveform: OscillatorType =
+    isValidLfoWaveform(initialWaveformParam) && !isSampleHoldWaveform
+      ? (initialWaveformParam as OscillatorType)
+      : "sine";
   let currentWaveform: LfoWaveform = initialWaveformParam;
   let isBipolar = parameters?.bipolar ?? true;
 
@@ -412,10 +417,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         isSyncEnabled = partial["syncEnabled"];
       }
 
-      if (
-        partial["bpm"] !== undefined &&
-        typeof partial["bpm"] === "number"
-      ) {
+      if (partial["bpm"] !== undefined && typeof partial["bpm"] === "number") {
         currentBpm = partial["bpm"];
       }
 
@@ -518,15 +520,27 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
 
           if (isNowHold && !wasHold) {
             // Switch to S&H: silence oscillator, activate S&H source
-            oscillatorRouteGain.gain.setValueAtTime(0, audioContext.currentTime);
-            sampleHoldRouteGain.gain.setValueAtTime(1, audioContext.currentTime);
+            oscillatorRouteGain.gain.setValueAtTime(
+              0,
+              audioContext.currentTime,
+            );
+            sampleHoldRouteGain.gain.setValueAtTime(
+              1,
+              audioContext.currentTime,
+            );
             sampleHoldStepIndex = 0;
             startSampleHoldTimer();
           } else if (!isNowHold && wasHold) {
             // Switch from S&H: activate oscillator, silence S&H source
             stopSampleHoldTimer();
-            oscillatorRouteGain.gain.setValueAtTime(1, audioContext.currentTime);
-            sampleHoldRouteGain.gain.setValueAtTime(0, audioContext.currentTime);
+            oscillatorRouteGain.gain.setValueAtTime(
+              1,
+              audioContext.currentTime,
+            );
+            sampleHoldRouteGain.gain.setValueAtTime(
+              0,
+              audioContext.currentTime,
+            );
             try {
               activeOscillatorNode.type = nextWaveform as OscillatorType;
             } catch {

--- a/src/modular/modules/LFO.ts
+++ b/src/modular/modules/LFO.ts
@@ -190,7 +190,12 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
     if (sampleHoldTimerId !== null) {
       clearInterval(sampleHoldTimerId);
     }
-    const rateHz = oscillatorNode.frequency.value;
+    const rateHz =
+      activeOscillatorNode?.frequency.value ?? oscillatorNode.frequency.value;
+    // Guard against zero or invalid rates to prevent Infinity interval
+    if (!Number.isFinite(rateHz) || rateHz <= 0) {
+      return;
+    }
     const intervalMs = (1 / rateHz) * 1000;
     updateSampleHoldValue(); // Set initial value immediately
     sampleHoldTimerId = setInterval(updateSampleHoldValue, intervalMs);
@@ -214,9 +219,9 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
   // For unipolar mode, we need to add a DC offset
   // Bipolar: oscillator output is -1..+1, multiplied by depth
   // Unipolar: we need to shift this to 0..+1
-  // We use a ConstantSource for the DC offset
+  // We use a ConstantSource for the DC offset (always 0.5, scaled by dcScaleNode)
   const dcOffsetNode = audioContext.createConstantSource();
-  dcOffsetNode.offset.value = isBipolar ? 0 : 0.5; // 0.5 shifts center from 0 to 0.5
+  dcOffsetNode.offset.value = 0.5; // Always 0.5, dcScaleNode controls whether it's applied
 
   // For unipolar, we also need to halve the oscillator amplitude
   // so that (osc * 0.5 * depth) + (0.5 * depth) ranges from 0 to depth
@@ -296,6 +301,14 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
 
     // Recreate the oscillator to reset phase
     const oldOscillator = activeOscillatorNode;
+
+    // Disconnect rateCvGainNode from old oscillator's frequency to prevent stale connections
+    try {
+      rateCvGainNode.disconnect(oldOscillator.frequency);
+    } catch {
+      /* may not be connected */
+    }
+
     try {
       oldOscillator.stop();
     } catch {
@@ -310,16 +323,23 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
     // Reconnect rate CV gain to the new oscillator frequency
     rateCvGainNode.connect(newOscillator.frequency);
     // Apply phase offset: start slightly in the past so the current phase matches offset
+    // Clamp to 0 to prevent negative start times early in session
     const rateHz = newOscillator.frequency.value;
     const offsetSeconds = rateHz > 0 ? currentPhaseOffset / rateHz : 0;
-    newOscillator.start(audioContext.currentTime - offsetSeconds);
+    const startTime = Math.max(0, audioContext.currentTime - offsetSeconds);
+    newOscillator.start(startTime);
     activeOscillatorNode = newOscillator;
   };
 
   // Start the oscillator with phase offset (start in the past to simulate phase offset)
+  // Clamp to 0 to prevent negative start times early in session
   const initialOffsetSeconds =
     initialRate > 0 ? currentPhaseOffset / initialRate : 0;
-  oscillatorNode.start(audioContext.currentTime - initialOffsetSeconds);
+  const initialStartTime = Math.max(
+    0,
+    audioContext.currentTime - initialOffsetSeconds,
+  );
+  oscillatorNode.start(initialStartTime);
   dcOffsetNode.start();
   sampleHoldSourceNode.start();
 
@@ -428,6 +448,9 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
         currentSyncDivision = partial["syncDivision"] as LfoSyncDivision;
       }
 
+      // Track if rate changed (for S&H timer restart)
+      let rateChanged = false;
+
       // If any sync-related param changed, recompute the rate
       if (
         partial["syncEnabled"] !== undefined ||
@@ -439,6 +462,7 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
           mode: "setTarget",
           timeConstant: 0.05,
         });
+        rateChanged = true;
       }
 
       if (
@@ -451,6 +475,12 @@ export const createLFO: CreateModuleFn<LFOParams> = (context, parameters) => {
           mode: "setTarget",
           timeConstant: 0.05,
         });
+        rateChanged = true;
+      }
+
+      // Restart S&H timer if rate changed and currently in S&H mode
+      if (rateChanged && currentWaveform === "sample_hold") {
+        startSampleHoldTimer();
       }
 
       if (

--- a/src/modular/modules/Saturator.ts
+++ b/src/modular/modules/Saturator.ts
@@ -11,6 +11,26 @@ export interface SaturatorParams {
 const ports: PortDefinition[] = [
   { id: "audio_in", label: "Audio In", direction: "in", signal: "AUDIO" },
   { id: "audio_out", label: "Audio Out", direction: "out", signal: "AUDIO" },
+  {
+    id: "drive_cv",
+    label: "Drive CV",
+    direction: "in",
+    signal: "CV",
+    metadata: {
+      bipolar: true,
+      description: "Drive modulation input (LFO, etc.)",
+    },
+  },
+  {
+    id: "mix_cv",
+    label: "Mix CV",
+    direction: "in",
+    signal: "CV",
+    metadata: {
+      bipolar: true,
+      description: "Mix/wet-dry modulation input",
+    },
+  },
 ];
 
 /**
@@ -83,9 +103,26 @@ export const createSaturator: CreateModuleFn<SaturatorParams> = (
   // Output
   mixerNode.connect(outputGainNode);
 
+  // === CV MODULATION INPUTS ===
+  // Drive CV: Scale CV signal to affect drive amount
+  // CV range -1..+1 maps to drive change of ±3 (adds to base drive)
+  const DRIVE_CV_SCALE = 3;
+  const driveCvScaleNode = audioContext.createGain();
+  driveCvScaleNode.gain.value = DRIVE_CV_SCALE;
+  driveCvScaleNode.connect(driveGainNode.gain);
+
+  // Mix CV: Modulates wet gain directly
+  // CV range -1..+1 maps to wet gain change of ±0.5
+  const MIX_CV_SCALE = 0.5;
+  const mixCvScaleNode = audioContext.createGain();
+  mixCvScaleNode.gain.value = MIX_CV_SCALE;
+  mixCvScaleNode.connect(wetGainNode.gain);
+
   const portNodes: ModuleInstance["portNodes"] = {
     audio_in: inputNode,
     audio_out: outputGainNode,
+    drive_cv: driveCvScaleNode,
+    mix_cv: mixCvScaleNode,
   };
 
   console.log(`[Saturator ${moduleId}] Created with:`, {
@@ -201,6 +238,8 @@ export const createSaturator: CreateModuleFn<SaturatorParams> = (
       wetGainNode.disconnect();
       mixerNode.disconnect();
       outputGainNode.disconnect();
+      driveCvScaleNode.disconnect();
+      mixCvScaleNode.disconnect();
     },
   };
 

--- a/src/modular/modules/VCF.ts
+++ b/src/modular/modules/VCF.ts
@@ -20,6 +20,16 @@ const ports: PortDefinition[] = [
     metadata: { bipolar: false },
   },
   { id: "env_cv", label: "Env CV", direction: "in", signal: "CV" },
+  {
+    id: "resonance_cv",
+    label: "Res CV",
+    direction: "in",
+    signal: "CV",
+    metadata: {
+      bipolar: true,
+      description: "Resonance/Q modulation input (LFO, etc.)",
+    },
+  },
 ];
 
 export const createVCF: CreateModuleFn<VCFParams> = (context, parameters) => {
@@ -53,6 +63,15 @@ export const createVCF: CreateModuleFn<VCFParams> = (context, parameters) => {
   // Chain: env_cv_input → inverter → scaler → frequency
   envelopeInverterNode.connect(envelopeScaleNode);
 
+  // Resonance CV scaling (LFO input scaled to Q range)
+  // Default scaling: CV signal (-1 to +1) maps to Q change of ±10
+  const RESONANCE_CV_SCALE = 10;
+  const resonanceCvScaleNode = audioContext.createGain();
+  resonanceCvScaleNode.gain.value = RESONANCE_CV_SCALE;
+
+  // Connect resonance CV to filter Q
+  resonanceCvScaleNode.connect(biquadFilterNode.Q);
+
   // Connect input drive -> filter
   inputGainNode.connect(biquadFilterNode);
 
@@ -67,6 +86,7 @@ export const createVCF: CreateModuleFn<VCFParams> = (context, parameters) => {
     audio_out: biquadFilterNode,
     cutoff_cv: biquadFilterNode.frequency,
     env_cv: envelopeInverterNode, // Envelope goes through inverter → scaler chain
+    resonance_cv: resonanceCvScaleNode, // LFO/CV input for resonance modulation
   };
 
   // Connect envelope chain to filter cutoff
@@ -185,6 +205,7 @@ export const createVCF: CreateModuleFn<VCFParams> = (context, parameters) => {
       biquadFilterNode.disconnect();
       envelopeInverterNode.disconnect();
       envelopeScaleNode.disconnect();
+      resonanceCvScaleNode.disconnect();
     },
   };
   return instance;

--- a/src/modular/modules/VCO.ts
+++ b/src/modular/modules/VCO.ts
@@ -34,6 +34,16 @@ const ports: PortDefinition[] = [
     metadata: { description: "Gate input for amplitude control" },
   },
   {
+    id: "gain_cv",
+    label: "Gain CV",
+    direction: "in",
+    signal: "CV",
+    metadata: {
+      bipolar: true,
+      description: "Gain/amplitude modulation (tremolo)",
+    },
+  },
+  {
     id: "sync",
     label: "Sync",
     direction: "in",
@@ -77,6 +87,13 @@ export const createVCO: CreateModuleFn<VCOParams> = (context, parameters) => {
   oscillatorNode.connect(vcaGainNode);
   vcaGainNode.connect(outputGainNode);
 
+  // Gain CV: Modulates output gain for tremolo effects
+  // CV range -1..+1 maps to gain change of ±0.3 (adds to base gain)
+  const GAIN_CV_SCALE = 0.3;
+  const gainCvScaleNode = audioContext.createGain();
+  gainCvScaleNode.gain.value = GAIN_CV_SCALE;
+  gainCvScaleNode.connect(outputGainNode.gain);
+
   // Start the oscillator
   oscillatorNode.start();
 
@@ -84,6 +101,7 @@ export const createVCO: CreateModuleFn<VCOParams> = (context, parameters) => {
     pitch_cv: oscillatorNode.frequency, // CV controls frequency directly when connected
     fm_cv: oscillatorNode.frequency, // For linear FM (direct Hz modulation)
     gate_in: vcaGainNode.gain, // Gate controls VCA gain directly (external gate signal adds to base value of 0)
+    gain_cv: gainCvScaleNode, // LFO/CV input for tremolo modulation
     sync: undefined,
     wave_cv: undefined,
     audio_out: outputGainNode,
@@ -209,6 +227,7 @@ export const createVCO: CreateModuleFn<VCOParams> = (context, parameters) => {
       oscillatorNode.disconnect();
       vcaGainNode.disconnect();
       outputGainNode.disconnect();
+      gainCvScaleNode.disconnect();
     },
   };
 

--- a/src/utils/lfoUtils.test.ts
+++ b/src/utils/lfoUtils.test.ts
@@ -16,6 +16,8 @@ import {
   LFO_DEPTH_MINIMUM,
   LFO_RATE_MAXIMUM,
   LFO_RATE_MINIMUM,
+  SAMPLE_HOLD_STEP_COUNT,
+  sampleHoldValueForStep,
   sampleLfoWaveform,
   tempoToLfoRate,
   unipolarToBipolar,
@@ -364,6 +366,58 @@ describe("lfoUtils", () => {
     it("should scale with BPM", () => {
       expect(calculateSyncedRate(60, "1/4")).toBeCloseTo(1);
       expect(calculateSyncedRate(240, "1/4")).toBeCloseTo(4);
+    });
+  });
+
+  describe("sampleHoldValueForStep", () => {
+    it("should return a value in [-1, +1]", () => {
+      for (let i = 0; i < 16; i++) {
+        const value = sampleHoldValueForStep(i);
+        expect(value).toBeGreaterThanOrEqual(-1);
+        expect(value).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it("should return the same value for the same step index", () => {
+      expect(sampleHoldValueForStep(0)).toBe(sampleHoldValueForStep(0));
+      expect(sampleHoldValueForStep(5)).toBe(sampleHoldValueForStep(5));
+      expect(sampleHoldValueForStep(100)).toBe(sampleHoldValueForStep(100));
+    });
+
+    it("should return different values for different step indices", () => {
+      const values = new Set(
+        Array.from({ length: 8 }, (_, i) => sampleHoldValueForStep(i)),
+      );
+      // Expect at least some variety in the values
+      expect(values.size).toBeGreaterThan(4);
+    });
+  });
+
+  describe("generateLfoWaveformSamples with sample_hold", () => {
+    it("should return correct number of samples", () => {
+      expect(generateLfoWaveformSamples("sample_hold", 64)).toHaveLength(64);
+    });
+
+    it("should produce step-like output (consecutive samples share the same value within a step)", () => {
+      const sampleCount = 128;
+      const samples = generateLfoWaveformSamples("sample_hold", sampleCount, 1, true);
+      // First two samples in the first step should be equal
+      const samplesPerStep = sampleCount / SAMPLE_HOLD_STEP_COUNT;
+      expect(samples[0]).toBe(samples[Math.floor(samplesPerStep / 2)]);
+    });
+
+    it("should produce bipolar output in [-1, +1] range", () => {
+      const samples = generateLfoWaveformSamples("sample_hold", 64, 1, true);
+      samples.forEach((s) => {
+        expect(s).toBeGreaterThanOrEqual(-1);
+        expect(s).toBeLessThanOrEqual(1);
+      });
+    });
+  });
+
+  describe("isValidLfoWaveform includes sample_hold", () => {
+    it("should accept sample_hold as valid waveform", () => {
+      expect(isValidLfoWaveform("sample_hold")).toBe(true);
     });
   });
 

--- a/src/utils/lfoUtils.test.ts
+++ b/src/utils/lfoUtils.test.ts
@@ -6,9 +6,11 @@ import {
   calculateModulatedValue,
   calculateSyncedRate,
   constrainLfoDepth,
+  constrainLfoPhaseOffset,
   constrainLfoRate,
   durationToLfoRate,
   formatLfoRate,
+  formatPhaseOffset,
   generateLfoWaveformSamples,
   getSyncDivisionSubdivision,
   isValidLfoWaveform,
@@ -366,6 +368,62 @@ describe("lfoUtils", () => {
     it("should scale with BPM", () => {
       expect(calculateSyncedRate(60, "1/4")).toBeCloseTo(1);
       expect(calculateSyncedRate(240, "1/4")).toBeCloseTo(4);
+    });
+  });
+
+  describe("constrainLfoPhaseOffset", () => {
+    it("should return 0 for 0", () => {
+      expect(constrainLfoPhaseOffset(0)).toBe(0);
+    });
+
+    it("should wrap 1.0 to 0", () => {
+      expect(constrainLfoPhaseOffset(1.0)).toBe(0);
+    });
+
+    it("should keep 0.5 as 0.5", () => {
+      expect(constrainLfoPhaseOffset(0.5)).toBe(0.5);
+    });
+
+    it("should wrap values greater than 1", () => {
+      expect(constrainLfoPhaseOffset(1.25)).toBeCloseTo(0.25);
+    });
+
+    it("should wrap negative values to positive", () => {
+      expect(constrainLfoPhaseOffset(-0.25)).toBeCloseTo(0.75);
+    });
+  });
+
+  describe("formatPhaseOffset", () => {
+    it("should format 0 as 0°", () => {
+      expect(formatPhaseOffset(0)).toBe("0°");
+    });
+
+    it("should format 0.25 as 90°", () => {
+      expect(formatPhaseOffset(0.25)).toBe("90°");
+    });
+
+    it("should format 0.5 as 180°", () => {
+      expect(formatPhaseOffset(0.5)).toBe("180°");
+    });
+
+    it("should format 0.75 as 270°", () => {
+      expect(formatPhaseOffset(0.75)).toBe("270°");
+    });
+  });
+
+  describe("generateLfoWaveformSamples with phaseOffset", () => {
+    it("should produce different samples with non-zero phaseOffset", () => {
+      const noOffset = generateLfoWaveformSamples("sine", 128, 1, true, 0);
+      const withOffset = generateLfoWaveformSamples("sine", 128, 1, true, 0.25);
+      expect(noOffset[0]).not.toBeCloseTo(withOffset[0]);
+    });
+
+    it("should shift the waveform by phaseOffset amount", () => {
+      // Sine at phase 0 = 0, at phase 0.25 = 1
+      const noOffset = generateLfoWaveformSamples("sine", 128, 1, true, 0);
+      const quarterOffset = generateLfoWaveformSamples("sine", 128, 1, true, 0.25);
+      // First sample with 0.25 offset should equal sample at index 32 with no offset
+      expect(quarterOffset[0]).toBeCloseTo(noOffset[32], 1);
     });
   });
 

--- a/src/utils/lfoUtils.test.ts
+++ b/src/utils/lfoUtils.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  bipolarToUnipolar,
+  calculateLfoPeriod,
+  calculateModulatedValue,
+  constrainLfoDepth,
+  constrainLfoRate,
+  durationToLfoRate,
+  formatLfoRate,
+  isValidLfoWaveform,
+  LFO_DEPTH_MAXIMUM,
+  LFO_DEPTH_MINIMUM,
+  LFO_RATE_MAXIMUM,
+  LFO_RATE_MINIMUM,
+  tempoToLfoRate,
+  unipolarToBipolar,
+} from "./lfoUtils";
+
+describe("lfoUtils", () => {
+  describe("constrainLfoRate", () => {
+    it("should return value when within range", () => {
+      expect(constrainLfoRate(1.0)).toBe(1.0);
+      expect(constrainLfoRate(10.0)).toBe(10.0);
+      expect(constrainLfoRate(0.5)).toBe(0.5);
+    });
+
+    it("should constrain to minimum when too low", () => {
+      expect(constrainLfoRate(0.001)).toBe(LFO_RATE_MINIMUM);
+      expect(constrainLfoRate(-5)).toBe(LFO_RATE_MINIMUM);
+      expect(constrainLfoRate(0)).toBe(LFO_RATE_MINIMUM);
+    });
+
+    it("should constrain to maximum when too high", () => {
+      expect(constrainLfoRate(100)).toBe(LFO_RATE_MAXIMUM);
+      expect(constrainLfoRate(1000)).toBe(LFO_RATE_MAXIMUM);
+    });
+
+    it("should accept boundary values", () => {
+      expect(constrainLfoRate(LFO_RATE_MINIMUM)).toBe(LFO_RATE_MINIMUM);
+      expect(constrainLfoRate(LFO_RATE_MAXIMUM)).toBe(LFO_RATE_MAXIMUM);
+    });
+  });
+
+  describe("constrainLfoDepth", () => {
+    it("should return value when within range", () => {
+      expect(constrainLfoDepth(0.5)).toBe(0.5);
+      expect(constrainLfoDepth(0.75)).toBe(0.75);
+    });
+
+    it("should constrain to minimum when too low", () => {
+      expect(constrainLfoDepth(-0.5)).toBe(LFO_DEPTH_MINIMUM);
+      expect(constrainLfoDepth(-100)).toBe(LFO_DEPTH_MINIMUM);
+    });
+
+    it("should constrain to maximum when too high", () => {
+      expect(constrainLfoDepth(1.5)).toBe(LFO_DEPTH_MAXIMUM);
+      expect(constrainLfoDepth(100)).toBe(LFO_DEPTH_MAXIMUM);
+    });
+
+    it("should accept boundary values", () => {
+      expect(constrainLfoDepth(0)).toBe(0);
+      expect(constrainLfoDepth(1)).toBe(1);
+    });
+  });
+
+  describe("isValidLfoWaveform", () => {
+    it("should return true for valid waveforms", () => {
+      expect(isValidLfoWaveform("sine")).toBe(true);
+      expect(isValidLfoWaveform("triangle")).toBe(true);
+      expect(isValidLfoWaveform("square")).toBe(true);
+      expect(isValidLfoWaveform("sawtooth")).toBe(true);
+    });
+
+    it("should return false for invalid waveforms", () => {
+      expect(isValidLfoWaveform("noise")).toBe(false);
+      expect(isValidLfoWaveform("random")).toBe(false);
+      expect(isValidLfoWaveform("")).toBe(false);
+      expect(isValidLfoWaveform("SINE")).toBe(false);
+    });
+  });
+
+  describe("bipolarToUnipolar", () => {
+    it("should convert -1 to 0", () => {
+      expect(bipolarToUnipolar(-1)).toBe(0);
+    });
+
+    it("should convert +1 to 1", () => {
+      expect(bipolarToUnipolar(1)).toBe(1);
+    });
+
+    it("should convert 0 to 0.5", () => {
+      expect(bipolarToUnipolar(0)).toBe(0.5);
+    });
+
+    it("should handle intermediate values", () => {
+      expect(bipolarToUnipolar(-0.5)).toBe(0.25);
+      expect(bipolarToUnipolar(0.5)).toBe(0.75);
+    });
+  });
+
+  describe("unipolarToBipolar", () => {
+    it("should convert 0 to -1", () => {
+      expect(unipolarToBipolar(0)).toBe(-1);
+    });
+
+    it("should convert 1 to +1", () => {
+      expect(unipolarToBipolar(1)).toBe(1);
+    });
+
+    it("should convert 0.5 to 0", () => {
+      expect(unipolarToBipolar(0.5)).toBe(0);
+    });
+
+    it("should handle intermediate values", () => {
+      expect(unipolarToBipolar(0.25)).toBe(-0.5);
+      expect(unipolarToBipolar(0.75)).toBe(0.5);
+    });
+
+    it("should be inverse of bipolarToUnipolar", () => {
+      const testValues = [-1, -0.5, 0, 0.5, 1];
+      for (const value of testValues) {
+        expect(unipolarToBipolar(bipolarToUnipolar(value))).toBeCloseTo(value);
+      }
+    });
+  });
+
+  describe("calculateModulatedValue", () => {
+    it("should return base value when LFO signal is 0", () => {
+      expect(calculateModulatedValue(100, 0, 50)).toBe(100);
+    });
+
+    it("should add full modulation amount when LFO signal is +1", () => {
+      expect(calculateModulatedValue(100, 1, 50)).toBe(150);
+    });
+
+    it("should subtract full modulation amount when LFO signal is -1", () => {
+      expect(calculateModulatedValue(100, -1, 50)).toBe(50);
+    });
+
+    it("should scale modulation by LFO signal value", () => {
+      expect(calculateModulatedValue(100, 0.5, 100)).toBe(150);
+      expect(calculateModulatedValue(100, -0.5, 100)).toBe(50);
+    });
+
+    it("should handle negative base values", () => {
+      expect(calculateModulatedValue(-10, 1, 5)).toBe(-5);
+    });
+
+    it("should handle zero modulation amount", () => {
+      expect(calculateModulatedValue(100, 1, 0)).toBe(100);
+    });
+  });
+
+  describe("calculateLfoPeriod", () => {
+    it("should calculate period from rate", () => {
+      expect(calculateLfoPeriod(1)).toBe(1);
+      expect(calculateLfoPeriod(2)).toBe(0.5);
+      expect(calculateLfoPeriod(0.5)).toBe(2);
+      expect(calculateLfoPeriod(10)).toBe(0.1);
+    });
+
+    it("should return Infinity for zero or negative rate", () => {
+      expect(calculateLfoPeriod(0)).toBe(Infinity);
+      expect(calculateLfoPeriod(-1)).toBe(Infinity);
+    });
+  });
+
+  describe("tempoToLfoRate", () => {
+    it("should calculate quarter note rate from BPM", () => {
+      // 120 BPM = 2 quarter notes per second = 2 Hz
+      expect(tempoToLfoRate(120, 4)).toBe(2);
+    });
+
+    it("should calculate eighth note rate from BPM", () => {
+      // 120 BPM = 4 eighth notes per second = 4 Hz
+      expect(tempoToLfoRate(120, 8)).toBe(4);
+    });
+
+    it("should calculate whole note rate from BPM", () => {
+      // 120 BPM = 0.5 whole notes per second = 0.5 Hz
+      expect(tempoToLfoRate(120, 1)).toBe(0.5);
+    });
+
+    it("should handle different tempos", () => {
+      // 60 BPM = 1 quarter note per second
+      expect(tempoToLfoRate(60, 4)).toBe(1);
+      // 180 BPM = 3 quarter notes per second
+      expect(tempoToLfoRate(180, 4)).toBe(3);
+    });
+
+    it("should handle invalid inputs gracefully", () => {
+      expect(tempoToLfoRate(0, 4)).toBe(1.0); // Default rate
+      expect(tempoToLfoRate(120, 0)).toBe(1.0); // Default rate
+      expect(tempoToLfoRate(-120, 4)).toBe(1.0); // Default rate
+    });
+  });
+
+  describe("durationToLfoRate", () => {
+    it("should calculate rate from duration", () => {
+      expect(durationToLfoRate(1)).toBe(1);
+      expect(durationToLfoRate(2)).toBe(0.5);
+      expect(durationToLfoRate(0.5)).toBe(2);
+    });
+
+    it("should constrain to valid rate range", () => {
+      // Very long duration = very low rate, constrained to minimum
+      expect(durationToLfoRate(1000)).toBe(LFO_RATE_MINIMUM);
+      // Very short duration = very high rate, constrained to maximum
+      expect(durationToLfoRate(0.001)).toBe(LFO_RATE_MAXIMUM);
+    });
+
+    it("should handle zero or negative duration", () => {
+      expect(durationToLfoRate(0)).toBe(LFO_RATE_MAXIMUM);
+      expect(durationToLfoRate(-1)).toBe(LFO_RATE_MAXIMUM);
+    });
+  });
+
+  describe("formatLfoRate", () => {
+    it("should format very slow rates with 3 decimal places", () => {
+      expect(formatLfoRate(0.015)).toBe("0.015");
+      expect(formatLfoRate(0.099)).toBe("0.099");
+    });
+
+    it("should format slow rates with 2 decimal places", () => {
+      expect(formatLfoRate(0.1)).toBe("0.10");
+      expect(formatLfoRate(0.55)).toBe("0.55");
+    });
+
+    it("should format moderate rates with 1 decimal place", () => {
+      expect(formatLfoRate(1.0)).toBe("1.0");
+      expect(formatLfoRate(5.5)).toBe("5.5");
+    });
+
+    it("should format fast rates with no decimal places", () => {
+      expect(formatLfoRate(10)).toBe("10");
+      expect(formatLfoRate(25.7)).toBe("26");
+    });
+  });
+});

--- a/src/utils/lfoUtils.test.ts
+++ b/src/utils/lfoUtils.test.ts
@@ -421,7 +421,13 @@ describe("lfoUtils", () => {
     it("should shift the waveform by phaseOffset amount", () => {
       // Sine at phase 0 = 0, at phase 0.25 = 1
       const noOffset = generateLfoWaveformSamples("sine", 128, 1, true, 0);
-      const quarterOffset = generateLfoWaveformSamples("sine", 128, 1, true, 0.25);
+      const quarterOffset = generateLfoWaveformSamples(
+        "sine",
+        128,
+        1,
+        true,
+        0.25,
+      );
       // First sample with 0.25 offset should equal sample at index 32 with no offset
       expect(quarterOffset[0]).toBeCloseTo(noOffset[32], 1);
     });
@@ -458,7 +464,12 @@ describe("lfoUtils", () => {
 
     it("should produce step-like output (consecutive samples share the same value within a step)", () => {
       const sampleCount = 128;
-      const samples = generateLfoWaveformSamples("sample_hold", sampleCount, 1, true);
+      const samples = generateLfoWaveformSamples(
+        "sample_hold",
+        sampleCount,
+        1,
+        true,
+      );
       // First two samples in the first step should be equal
       const samplesPerStep = sampleCount / SAMPLE_HOLD_STEP_COUNT;
       expect(samples[0]).toBe(samples[Math.floor(samplesPerStep / 2)]);

--- a/src/utils/lfoUtils.test.ts
+++ b/src/utils/lfoUtils.test.ts
@@ -4,11 +4,13 @@ import {
   bipolarToUnipolar,
   calculateLfoPeriod,
   calculateModulatedValue,
+  calculateSyncedRate,
   constrainLfoDepth,
   constrainLfoRate,
   durationToLfoRate,
   formatLfoRate,
   generateLfoWaveformSamples,
+  getSyncDivisionSubdivision,
   isValidLfoWaveform,
   LFO_DEPTH_MAXIMUM,
   LFO_DEPTH_MINIMUM,
@@ -312,6 +314,56 @@ describe("lfoUtils", () => {
       expect(sampleLfoWaveform("sine", -0.75)).toBeCloseTo(
         sampleLfoWaveform("sine", 0.25),
       );
+    });
+  });
+
+  describe("getSyncDivisionSubdivision", () => {
+    it("should return correct subdivision for whole note", () => {
+      expect(getSyncDivisionSubdivision("1/1")).toBe(1);
+    });
+
+    it("should return correct subdivision for quarter note", () => {
+      expect(getSyncDivisionSubdivision("1/4")).toBeCloseTo(0.25);
+    });
+
+    it("should return correct subdivision for 4/1 (4 whole notes)", () => {
+      expect(getSyncDivisionSubdivision("4/1")).toBe(4);
+    });
+
+    it("should return correct subdivision for 1/32", () => {
+      expect(getSyncDivisionSubdivision("1/32")).toBeCloseTo(1 / 32);
+    });
+  });
+
+  describe("calculateSyncedRate", () => {
+    it("should calculate correct rate for quarter note at 120 BPM", () => {
+      // 120 BPM → quarter note = 2 Hz
+      expect(calculateSyncedRate(120, "1/4")).toBeCloseTo(2);
+    });
+
+    it("should calculate correct rate for half note at 120 BPM", () => {
+      // 120 BPM → half note = 1 Hz
+      expect(calculateSyncedRate(120, "1/2")).toBeCloseTo(1);
+    });
+
+    it("should calculate correct rate for whole note at 120 BPM", () => {
+      // 120 BPM → whole note = 0.5 Hz
+      expect(calculateSyncedRate(120, "1/1")).toBeCloseTo(0.5);
+    });
+
+    it("should calculate correct rate for 4/1 at 120 BPM", () => {
+      // 4 whole notes = 0.125 Hz at 120 BPM (clamped to LFO_RATE_MINIMUM)
+      expect(calculateSyncedRate(120, "4/1")).toBeCloseTo(0.125);
+    });
+
+    it("should calculate correct rate for 1/8 at 120 BPM", () => {
+      // 120 BPM → eighth note = 4 Hz
+      expect(calculateSyncedRate(120, "1/8")).toBeCloseTo(4);
+    });
+
+    it("should scale with BPM", () => {
+      expect(calculateSyncedRate(60, "1/4")).toBeCloseTo(1);
+      expect(calculateSyncedRate(240, "1/4")).toBeCloseTo(4);
     });
   });
 

--- a/src/utils/lfoUtils.test.ts
+++ b/src/utils/lfoUtils.test.ts
@@ -8,11 +8,13 @@ import {
   constrainLfoRate,
   durationToLfoRate,
   formatLfoRate,
+  generateLfoWaveformSamples,
   isValidLfoWaveform,
   LFO_DEPTH_MAXIMUM,
   LFO_DEPTH_MINIMUM,
   LFO_RATE_MAXIMUM,
   LFO_RATE_MINIMUM,
+  sampleLfoWaveform,
   tempoToLfoRate,
   unipolarToBipolar,
 } from "./lfoUtils";
@@ -235,6 +237,112 @@ describe("lfoUtils", () => {
     it("should format fast rates with no decimal places", () => {
       expect(formatLfoRate(10)).toBe("10");
       expect(formatLfoRate(25.7)).toBe("26");
+    });
+  });
+
+  describe("sampleLfoWaveform", () => {
+    describe("sine", () => {
+      it("should return 0 at phase 0", () => {
+        expect(sampleLfoWaveform("sine", 0)).toBeCloseTo(0);
+      });
+
+      it("should return 1 at phase 0.25 (peak)", () => {
+        expect(sampleLfoWaveform("sine", 0.25)).toBeCloseTo(1);
+      });
+
+      it("should return 0 at phase 0.5", () => {
+        expect(sampleLfoWaveform("sine", 0.5)).toBeCloseTo(0);
+      });
+
+      it("should return -1 at phase 0.75 (trough)", () => {
+        expect(sampleLfoWaveform("sine", 0.75)).toBeCloseTo(-1);
+      });
+    });
+
+    describe("triangle", () => {
+      it("should return 0 at phase 0", () => {
+        expect(sampleLfoWaveform("triangle", 0)).toBeCloseTo(0);
+      });
+
+      it("should return 1 at phase 0.25 (peak)", () => {
+        expect(sampleLfoWaveform("triangle", 0.25)).toBeCloseTo(1);
+      });
+
+      it("should return 0 at phase 0.5", () => {
+        expect(sampleLfoWaveform("triangle", 0.5)).toBeCloseTo(0);
+      });
+
+      it("should return -1 at phase 0.75 (trough)", () => {
+        expect(sampleLfoWaveform("triangle", 0.75)).toBeCloseTo(-1);
+      });
+    });
+
+    describe("square", () => {
+      it("should return 1 in first half", () => {
+        expect(sampleLfoWaveform("square", 0)).toBe(1);
+        expect(sampleLfoWaveform("square", 0.25)).toBe(1);
+        expect(sampleLfoWaveform("square", 0.49)).toBe(1);
+      });
+
+      it("should return -1 in second half", () => {
+        expect(sampleLfoWaveform("square", 0.5)).toBe(-1);
+        expect(sampleLfoWaveform("square", 0.75)).toBe(-1);
+        expect(sampleLfoWaveform("square", 0.99)).toBe(-1);
+      });
+    });
+
+    describe("sawtooth", () => {
+      it("should return -1 at phase 0", () => {
+        expect(sampleLfoWaveform("sawtooth", 0)).toBeCloseTo(-1);
+      });
+
+      it("should return 0 at phase 0.5", () => {
+        expect(sampleLfoWaveform("sawtooth", 0.5)).toBeCloseTo(0);
+      });
+
+      it("should approach +1 near phase 1", () => {
+        expect(sampleLfoWaveform("sawtooth", 0.999)).toBeCloseTo(1, 1);
+      });
+    });
+
+    it("should wrap phase values correctly", () => {
+      expect(sampleLfoWaveform("sine", 1.25)).toBeCloseTo(
+        sampleLfoWaveform("sine", 0.25),
+      );
+      expect(sampleLfoWaveform("sine", -0.75)).toBeCloseTo(
+        sampleLfoWaveform("sine", 0.25),
+      );
+    });
+  });
+
+  describe("generateLfoWaveformSamples", () => {
+    it("should generate correct number of samples", () => {
+      expect(generateLfoWaveformSamples("sine", 64)).toHaveLength(64);
+      expect(generateLfoWaveformSamples("sine", 128)).toHaveLength(128);
+    });
+
+    it("should scale by depth", () => {
+      const fullDepth = generateLfoWaveformSamples("sine", 128, 1, true);
+      const halfDepth = generateLfoWaveformSamples("sine", 128, 0.5, true);
+      // Peak of sine at sample ~32 (phase 0.25)
+      const peakIndex = 32;
+      expect(halfDepth[peakIndex]).toBeCloseTo(fullDepth[peakIndex] * 0.5);
+    });
+
+    it("should produce unipolar output when bipolar is false", () => {
+      const samples = generateLfoWaveformSamples("sine", 128, 1, false);
+      const minValue = Math.min(...samples);
+      const maxValue = Math.max(...samples);
+      expect(minValue).toBeGreaterThanOrEqual(-0.01);
+      expect(maxValue).toBeLessThanOrEqual(1.01);
+    });
+
+    it("should produce bipolar output when bipolar is true", () => {
+      const samples = generateLfoWaveformSamples("sine", 128, 1, true);
+      const minValue = Math.min(...samples);
+      const maxValue = Math.max(...samples);
+      expect(minValue).toBeCloseTo(-1, 1);
+      expect(maxValue).toBeCloseTo(1, 1);
     });
   });
 });

--- a/src/utils/lfoUtils.ts
+++ b/src/utils/lfoUtils.ts
@@ -96,6 +96,33 @@ export const LFO_WAVEFORMS: readonly LfoWaveform[] = [
 ] as const;
 
 /**
+ * LFO phase offset range (0 = no offset, 1 = full cycle = same as 0)
+ */
+export const LFO_PHASE_OFFSET_MINIMUM = 0;
+export const LFO_PHASE_OFFSET_MAXIMUM = 1;
+export const LFO_PHASE_OFFSET_DEFAULT = 0;
+
+/**
+ * Constrains a phase offset to [0, 1) by wrapping around.
+ * @param phaseOffset - Phase offset as a fraction of one cycle (0..1)
+ * @returns Normalized phase offset in [0, 1)
+ */
+export function constrainLfoPhaseOffset(phaseOffset: number): number {
+  const normalized = phaseOffset % 1;
+  return normalized < 0 ? normalized + 1 : normalized;
+}
+
+/**
+ * Formats a phase offset (0..1) as a degree value (0°..359°).
+ * @param phaseOffset - Phase offset as a fraction (0..1)
+ * @returns Formatted string like "90°"
+ */
+export function formatPhaseOffset(phaseOffset: number): string {
+  const degrees = Math.round(constrainLfoPhaseOffset(phaseOffset) * 360);
+  return `${degrees}°`;
+}
+
+/**
  * LFO rate constraints in Hz
  */
 export const LFO_RATE_MINIMUM = 0.01;
@@ -294,6 +321,7 @@ export const SAMPLE_HOLD_STEP_COUNT = 8;
  * @param sampleCount - Number of samples to generate
  * @param depth - Amplitude scaling (0 to 1)
  * @param bipolar - If true, output range is -depth..+depth; if false, 0..+depth
+ * @param phaseOffset - Starting phase offset as a fraction of one cycle (0..1)
  * @returns Array of sample values
  */
 export function generateLfoWaveformSamples(
@@ -301,17 +329,20 @@ export function generateLfoWaveformSamples(
   sampleCount: number,
   depth: number = 1,
   bipolar: boolean = true,
+  phaseOffset: number = 0,
 ): number[] {
+  const normalizedOffset = constrainLfoPhaseOffset(phaseOffset);
   const samples: number[] = [];
   for (let i = 0; i < sampleCount; i++) {
     let value: number;
     if (waveform === "sample_hold") {
-      // Divide the cycle into SAMPLE_HOLD_STEP_COUNT equal steps
-      const stepIndex = Math.floor((i / sampleCount) * SAMPLE_HOLD_STEP_COUNT);
+      // Divide the cycle into SAMPLE_HOLD_STEP_COUNT equal steps, offset by phase
+      const phase = (i / sampleCount + normalizedOffset) % 1;
+      const stepIndex = Math.floor(phase * SAMPLE_HOLD_STEP_COUNT);
       const bipolarValue = sampleHoldValueForStep(stepIndex) * depth;
       value = bipolar ? bipolarValue : (bipolarValue + depth) / 2;
     } else {
-      const phase = i / sampleCount;
+      const phase = i / sampleCount + normalizedOffset;
       value = sampleLfoWaveform(waveform, phase) * depth;
       if (!bipolar) {
         // Convert from bipolar (-depth..+depth) to unipolar (0..+depth)

--- a/src/utils/lfoUtils.ts
+++ b/src/utils/lfoUtils.ts
@@ -1,0 +1,157 @@
+/**
+ * LFO (Low Frequency Oscillator) utility functions for modulation calculations.
+ * All functions are pure (no side effects, same input = same output).
+ */
+
+import { constrainToRange } from "./mathUtils";
+
+/**
+ * LFO waveform types supported by the synthesizer
+ */
+export type LfoWaveform = "sine" | "triangle" | "square" | "sawtooth";
+
+/**
+ * Valid LFO waveform values for validation
+ */
+export const LFO_WAVEFORMS: readonly LfoWaveform[] = [
+  "sine",
+  "triangle",
+  "square",
+  "sawtooth",
+] as const;
+
+/**
+ * LFO rate constraints in Hz
+ */
+export const LFO_RATE_MINIMUM = 0.01;
+export const LFO_RATE_MAXIMUM = 50;
+export const LFO_RATE_DEFAULT = 1.0;
+
+/**
+ * LFO depth constraints (normalized 0-1)
+ */
+export const LFO_DEPTH_MINIMUM = 0;
+export const LFO_DEPTH_MAXIMUM = 1;
+export const LFO_DEPTH_DEFAULT = 1.0;
+
+/**
+ * Validates and constrains an LFO rate value to the valid range
+ * @param rate - The rate value to validate
+ * @returns The constrained rate in Hz
+ */
+export function constrainLfoRate(rate: number): number {
+  return constrainToRange(rate, LFO_RATE_MINIMUM, LFO_RATE_MAXIMUM);
+}
+
+/**
+ * Validates and constrains an LFO depth value to the valid range
+ * @param depth - The depth value to validate
+ * @returns The constrained depth (0-1)
+ */
+export function constrainLfoDepth(depth: number): number {
+  return constrainToRange(depth, LFO_DEPTH_MINIMUM, LFO_DEPTH_MAXIMUM);
+}
+
+/**
+ * Checks if a waveform string is a valid LFO waveform type
+ * @param waveform - The waveform string to check
+ * @returns True if valid LFO waveform
+ */
+export function isValidLfoWaveform(waveform: string): waveform is LfoWaveform {
+  return LFO_WAVEFORMS.includes(waveform as LfoWaveform);
+}
+
+/**
+ * Converts a bipolar signal (-1 to +1) to a unipolar signal (0 to 1)
+ * @param bipolarValue - The bipolar value (-1 to +1)
+ * @returns The unipolar value (0 to 1)
+ */
+export function bipolarToUnipolar(bipolarValue: number): number {
+  return (bipolarValue + 1) / 2;
+}
+
+/**
+ * Converts a unipolar signal (0 to 1) to a bipolar signal (-1 to +1)
+ * @param unipolarValue - The unipolar value (0 to 1)
+ * @returns The bipolar value (-1 to +1)
+ */
+export function unipolarToBipolar(unipolarValue: number): number {
+  return unipolarValue * 2 - 1;
+}
+
+/**
+ * Calculates the modulated parameter value given a base value, LFO signal, and modulation amount
+ * @param baseValue - The base parameter value (e.g., base cutoff frequency)
+ * @param lfoSignal - The LFO signal value (typically -1 to +1 or 0 to 1)
+ * @param modulationAmount - The amount of modulation to apply (in parameter units)
+ * @returns The modulated parameter value
+ */
+export function calculateModulatedValue(
+  baseValue: number,
+  lfoSignal: number,
+  modulationAmount: number,
+): number {
+  return baseValue + lfoSignal * modulationAmount;
+}
+
+/**
+ * Calculates the period of an LFO in seconds given its rate
+ * @param rateHz - The LFO rate in Hz
+ * @returns The period in seconds
+ */
+export function calculateLfoPeriod(rateHz: number): number {
+  if (rateHz <= 0) {
+    return Infinity;
+  }
+  return 1 / rateHz;
+}
+
+/**
+ * Converts LFO rate in Hz to a musical tempo subdivision
+ * Useful for syncing LFO to tempo (e.g., 1/4 note at 120 BPM = 2 Hz)
+ * @param bpm - The tempo in beats per minute
+ * @param subdivision - Note subdivision (1 = whole, 2 = half, 4 = quarter, 8 = eighth, etc.)
+ * @returns The equivalent LFO rate in Hz
+ */
+export function tempoToLfoRate(bpm: number, subdivision: number): number {
+  if (bpm <= 0 || subdivision <= 0) {
+    return LFO_RATE_DEFAULT;
+  }
+  // BPM gives quarter notes per minute
+  // subdivision 1 = whole note = 1/4 the rate of quarter notes
+  // subdivision 4 = quarter note = same rate as BPM
+  // subdivision 8 = eighth note = 2x the rate of quarter notes
+  const quarterNoteHz = bpm / 60;
+  const wholeNoteHz = quarterNoteHz / 4;
+  return wholeNoteHz * subdivision;
+}
+
+/**
+ * Calculates the LFO rate needed to complete one cycle over a given duration
+ * @param durationSeconds - The desired cycle duration in seconds
+ * @returns The LFO rate in Hz
+ */
+export function durationToLfoRate(durationSeconds: number): number {
+  if (durationSeconds <= 0) {
+    return LFO_RATE_MAXIMUM;
+  }
+  return constrainLfoRate(1 / durationSeconds);
+}
+
+/**
+ * Formats an LFO rate for display, showing appropriate precision
+ * @param rateHz - The rate in Hz
+ * @returns A formatted string with appropriate decimal places
+ */
+export function formatLfoRate(rateHz: number): string {
+  if (rateHz < 0.1) {
+    return rateHz.toFixed(3);
+  }
+  if (rateHz < 1) {
+    return rateHz.toFixed(2);
+  }
+  if (rateHz < 10) {
+    return rateHz.toFixed(1);
+  }
+  return rateHz.toFixed(0);
+}

--- a/src/utils/lfoUtils.ts
+++ b/src/utils/lfoUtils.ts
@@ -11,6 +11,75 @@ import { constrainToRange } from "./mathUtils";
 export type LfoWaveform = "sine" | "triangle" | "square" | "sawtooth";
 
 /**
+ * Musical note divisions for tempo-synced LFO rates
+ * Format: "numerator/denominator" where 1/1 = one whole note per cycle
+ */
+export type LfoSyncDivision =
+  | "4/1"
+  | "2/1"
+  | "1/1"
+  | "1/2"
+  | "1/4"
+  | "1/8"
+  | "1/16"
+  | "1/32";
+
+/**
+ * All valid sync divisions in order from slowest to fastest
+ */
+export const LFO_SYNC_DIVISIONS: readonly LfoSyncDivision[] = [
+  "4/1",
+  "2/1",
+  "1/1",
+  "1/2",
+  "1/4",
+  "1/8",
+  "1/16",
+  "1/32",
+] as const;
+
+/** Default sync division */
+export const LFO_SYNC_DIVISION_DEFAULT: LfoSyncDivision = "1/4";
+
+/** Default BPM for tempo sync */
+export const LFO_BPM_DEFAULT = 120;
+
+/** Minimum BPM */
+export const LFO_BPM_MINIMUM = 20;
+
+/** Maximum BPM */
+export const LFO_BPM_MAXIMUM = 300;
+
+/**
+ * Returns the fractional subdivision value for a sync division string.
+ * A value of 1 = one whole note, 4 = four cycles per whole note, etc.
+ * @param division - The sync division string (e.g. "1/4")
+ * @returns The numeric subdivision value (numerator/denominator)
+ */
+export function getSyncDivisionSubdivision(division: LfoSyncDivision): number {
+  const [numerator, denominator] = division.split("/").map(Number);
+  return numerator / denominator;
+}
+
+/**
+ * Calculates the LFO rate in Hz for a given BPM and sync division.
+ * Division "1/4" means one LFO cycle per quarter note.
+ * @param bpm - Tempo in beats per minute
+ * @param division - Note division for sync (e.g. "1/4" = quarter note)
+ * @returns The LFO rate in Hz
+ */
+export function calculateSyncedRate(
+  bpm: number,
+  division: LfoSyncDivision,
+): number {
+  // getSyncDivisionSubdivision("1/4") = 0.25 (fraction of a whole note)
+  // tempoToLfoRate expects subdivision where 4 = quarter note, 8 = eighth note, etc.
+  // So we pass 1 / fraction: "1/4" → 1/0.25 = 4 → quarter note rate
+  const fraction = getSyncDivisionSubdivision(division);
+  return constrainLfoRate(tempoToLfoRate(bpm, 1 / fraction));
+}
+
+/**
  * Valid LFO waveform values for validation
  */
 export const LFO_WAVEFORMS: readonly LfoWaveform[] = [

--- a/src/utils/lfoUtils.ts
+++ b/src/utils/lfoUtils.ts
@@ -155,3 +155,66 @@ export function formatLfoRate(rateHz: number): string {
   }
   return rateHz.toFixed(0);
 }
+
+/**
+ * Samples a waveform at a given phase position (0 to 1 representing one full cycle).
+ * Returns a bipolar value (-1 to +1).
+ * @param waveform - The waveform type to sample
+ * @param phase - The phase position (0 to 1, wraps around)
+ * @returns The waveform value at the given phase (-1 to +1)
+ */
+export function sampleLfoWaveform(
+  waveform: LfoWaveform,
+  phase: number,
+): number {
+  // Normalize phase to [0, 1)
+  const normalizedPhase = ((phase % 1) + 1) % 1;
+
+  switch (waveform) {
+    case "sine":
+      return Math.sin(normalizedPhase * 2 * Math.PI);
+    case "triangle":
+      // Triangle: rises 0→1 in first quarter, 1→-1 in middle half, -1→0 in last quarter
+      if (normalizedPhase < 0.25) {
+        return normalizedPhase * 4;
+      }
+      if (normalizedPhase < 0.75) {
+        return 1 - (normalizedPhase - 0.25) * 4;
+      }
+      return -1 + (normalizedPhase - 0.75) * 4;
+    case "square":
+      return normalizedPhase < 0.5 ? 1 : -1;
+    case "sawtooth":
+      // Sawtooth: rises from -1 to +1 over the cycle (Web Audio convention)
+      return normalizedPhase * 2 - 1;
+    default:
+      return 0;
+  }
+}
+
+/**
+ * Generates an array of waveform samples for visualization.
+ * @param waveform - The waveform type
+ * @param sampleCount - Number of samples to generate
+ * @param depth - Amplitude scaling (0 to 1)
+ * @param bipolar - If true, output range is -depth..+depth; if false, 0..+depth
+ * @returns Array of sample values
+ */
+export function generateLfoWaveformSamples(
+  waveform: LfoWaveform,
+  sampleCount: number,
+  depth: number = 1,
+  bipolar: boolean = true,
+): number[] {
+  const samples: number[] = [];
+  for (let i = 0; i < sampleCount; i++) {
+    const phase = i / sampleCount;
+    let value = sampleLfoWaveform(waveform, phase) * depth;
+    if (!bipolar) {
+      // Convert from bipolar (-depth..+depth) to unipolar (0..+depth)
+      value = (value + depth) / 2;
+    }
+    samples.push(value);
+  }
+  return samples;
+}

--- a/src/utils/lfoUtils.ts
+++ b/src/utils/lfoUtils.ts
@@ -118,7 +118,8 @@ export function constrainLfoPhaseOffset(phaseOffset: number): number {
  * @returns Formatted string like "90°"
  */
 export function formatPhaseOffset(phaseOffset: number): string {
-  const degrees = Math.round(constrainLfoPhaseOffset(phaseOffset) * 360);
+  // Apply modulo 360 after rounding to ensure 0°–359° range (not 360°)
+  const degrees = Math.round(constrainLfoPhaseOffset(phaseOffset) * 360) % 360;
   return `${degrees}°`;
 }
 

--- a/src/utils/lfoUtils.ts
+++ b/src/utils/lfoUtils.ts
@@ -8,7 +8,12 @@ import { constrainToRange } from "./mathUtils";
 /**
  * LFO waveform types supported by the synthesizer
  */
-export type LfoWaveform = "sine" | "triangle" | "square" | "sawtooth";
+export type LfoWaveform =
+  | "sine"
+  | "triangle"
+  | "square"
+  | "sawtooth"
+  | "sample_hold";
 
 /**
  * Musical note divisions for tempo-synced LFO rates
@@ -87,6 +92,7 @@ export const LFO_WAVEFORMS: readonly LfoWaveform[] = [
   "triangle",
   "square",
   "sawtooth",
+  "sample_hold",
 ] as const;
 
 /**
@@ -256,13 +262,34 @@ export function sampleLfoWaveform(
     case "sawtooth":
       // Sawtooth: rises from -1 to +1 over the cycle (Web Audio convention)
       return normalizedPhase * 2 - 1;
+    case "sample_hold":
+      // S&H is step-based; use sampleHoldValueForStep with a single-step index of 0
+      // Phase-based S&H visualization is handled via generateLfoWaveformSamples
+      return sampleHoldValueForStep(0);
     default:
       return 0;
   }
 }
 
 /**
+ * Returns a deterministic pseudo-random value for a given Sample & Hold step index.
+ * The same step index always produces the same value, enabling reproducible visualization.
+ * @param stepIndex - The step index (non-negative integer)
+ * @returns A bipolar value in range [-1, +1]
+ */
+export function sampleHoldValueForStep(stepIndex: number): number {
+  // Simple deterministic hash function for a consistent pseudo-random sequence
+  const hash = Math.sin(stepIndex * 12.9898 + 78.233) * 43758.5453;
+  const normalized = hash - Math.floor(hash); // 0..1
+  return normalized * 2 - 1; // -1..+1
+}
+
+/** Default number of S&H steps visible in one waveform preview cycle */
+export const SAMPLE_HOLD_STEP_COUNT = 8;
+
+/**
  * Generates an array of waveform samples for visualization.
+ * For "sample_hold", produces a stepped random waveform using SAMPLE_HOLD_STEP_COUNT steps.
  * @param waveform - The waveform type
  * @param sampleCount - Number of samples to generate
  * @param depth - Amplitude scaling (0 to 1)
@@ -277,11 +304,19 @@ export function generateLfoWaveformSamples(
 ): number[] {
   const samples: number[] = [];
   for (let i = 0; i < sampleCount; i++) {
-    const phase = i / sampleCount;
-    let value = sampleLfoWaveform(waveform, phase) * depth;
-    if (!bipolar) {
-      // Convert from bipolar (-depth..+depth) to unipolar (0..+depth)
-      value = (value + depth) / 2;
+    let value: number;
+    if (waveform === "sample_hold") {
+      // Divide the cycle into SAMPLE_HOLD_STEP_COUNT equal steps
+      const stepIndex = Math.floor((i / sampleCount) * SAMPLE_HOLD_STEP_COUNT);
+      const bipolarValue = sampleHoldValueForStep(stepIndex) * depth;
+      value = bipolar ? bipolarValue : (bipolarValue + depth) / 2;
+    } else {
+      const phase = i / sampleCount;
+      value = sampleLfoWaveform(waveform, phase) * depth;
+      if (!bipolar) {
+        // Convert from bipolar (-depth..+depth) to unipolar (0..+depth)
+        value = (value + depth) / 2;
+      }
     }
     samples.push(value);
   }


### PR DESCRIPTION
Implement a new Low Frequency Oscillator (LFO) module for parameter modulation:

LFO Module Features:
- Waveforms: sine, triangle, square, sawtooth
- Rate: 0.01 Hz to 50 Hz with smooth transitions
- Depth: 0 to 1 normalized output amplitude
- Bipolar/Unipolar output modes (-1..+1 or 0..+1)
- CV output and inverted CV output ports
- Rate CV input for rate modulation (future)
- Reset trigger input (future)

New CV Modulation Inputs:
- VCO: gain_cv port for tremolo effects
- VCF: resonance_cv port for Q modulation
- Saturator: drive_cv and mix_cv ports for dynamic effects

Also includes:
- LFO utility functions with 39 comprehensive unit tests
- LFOControls UI component with toggle buttons
- CSS styles for toggle button groups
- Registration in PatchWorkspace palette